### PR TITLE
Add MQTT contract and performance documentation

### DIFF
--- a/docs/MQTT_CONTRACT.md
+++ b/docs/MQTT_CONTRACT.md
@@ -1,0 +1,40 @@
+# MQTT Contract
+
+This document summarizes the MQTT interface expectations for the M5Tab5 User Demo so firmware, mobile, and cloud teams can exchange telemetry and commands consistently.
+
+## Topic Names
+
+| Topic | Direction | Description |
+| --- | --- | --- |
+| `device/{deviceId}/status` | Device → Cloud | Periodic heartbeat including connectivity and firmware metadata. |
+| `device/{deviceId}/telemetry` | Device → Cloud | Sensor readings such as temperature, humidity, and button state. |
+| `device/{deviceId}/command` | Cloud → Device | Downstream instructions for UI updates, configuration changes, or resets. |
+| `device/{deviceId}/ack` | Device → Cloud | Acknowledgements for command execution with success and error codes. |
+
+All topics are namespaced per device using the stable `deviceId` assigned during provisioning. Avoid sharing topics between devices to preserve isolation and traceability.
+
+## Payload Schemas
+
+* **Status**: JSON object with `uptimeSeconds`, `firmwareVersion`, and `batteryPercent` fields.
+* **Telemetry**: JSON array of objects with `metric`, `value`, and `timestamp` (ISO-8601) fields. This allows batching multiple readings per publish to reduce overhead.
+* **Command**: JSON object specifying `type`, optional `parameters`, and `commandId` that the device must echo in the acknowledgement.
+* **Acknowledgement**: JSON object with `commandId`, `result` (`"ok"` or `"error"`), and optional `errorDetail` string.
+
+Where feasible, validate payloads against JSON Schema definitions embedded in integration tests to prevent regressions.
+
+## QoS Expectations
+
+* **Status**: QoS 0 is acceptable because the payload repeats frequently.
+* **Telemetry**: QoS 1 ensures reliable delivery of sensor data while balancing latency.
+* **Command**: QoS 1 is recommended so devices do not miss downstream instructions.
+* **Acknowledgement**: QoS 0 is sufficient because command retries trigger additional acknowledgements.
+
+Retained messages are only enabled for `device/{deviceId}/status` so the cloud can immediately assess last-seen device state.
+
+## Operational Guidance
+
+* Batch publishes to stay within broker rate limits while keeping telemetry latency under 5 seconds.
+* Leverage shared subscriptions for cloud workers processing telemetry at scale.
+* Monitor broker metrics (connection count, inflight messages) to catch backpressure early.
+
+For roadmap alignment and upcoming milestones, see [TASKS.md](./TASKS.md).

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,36 @@
+# Performance Guidelines
+
+This guide documents the performance targets and diagnostic practices for the M5Tab5 User Demo so contributors can sustain a smooth user experience on constrained hardware.
+
+## Frame-Rate Targets
+
+| Scenario | Target FPS | Notes |
+| --- | --- | --- |
+| Idle dashboard | 30 FPS | Maintain smooth widget animations with minimal CPU wakeups. |
+| Touch interactions | 45 FPS | Prioritize responsiveness during gesture handling and feedback. |
+| Sensor visualization mode | 25 FPS | Balance refresh rate with data plotting complexity. |
+
+Measure frame rate on-device using the built-in LVGL performance counters and log spikes above ±10% variance.
+
+## Memory Limits
+
+* **Total RAM budget**: 24 MB, including LVGL heap, network stack, and sensor buffers.
+* **Display buffer**: Cap double-buffered LVGL draw buffers at 6 MB to leave headroom for application tasks.
+* **Asset storage**: Keep in-memory icon and font caches below 4 MB; evict infrequently used assets aggressively.
+
+Use the platform's heap tracing utilities to verify that steady-state usage remains below 80% of available RAM and that fragmentation stays under 10%.
+
+## Profiling Tips
+
+1. Enable LVGL's built-in profiler (`LV_USE_PERF_MONITOR = 1`) during development builds to capture CPU time per task.
+2. Capture flame graphs with `perf` or `esp32-coredump` sampling when average frame time exceeds 33 ms.
+3. Instrument MQTT handlers with timestamped logs to correlate network events with UI slowdowns.
+4. Automate regression detection by tracking FPS and heap metrics in CI hardware-in-the-loop runs.
+
+## Optimization Checklist
+
+* Batch GPU-bound draw calls to minimize bus contention.
+* Defer non-critical telemetry publishes when frame latency spikes.
+* Compress large images and prefer indexed color palettes for UI assets.
+
+For task breakdowns and prioritization guidance, see [TASKS.md](./TASKS.md).


### PR DESCRIPTION
## Summary
- add MQTT documentation detailing topic conventions, payload schemas, and QoS levels
- document performance targets including frame rate, memory budgets, and profiling practices
- cross-link new docs back to TASKS overview for roadmap context

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68c90faa22e0832493f30a8845381946