### PR TITLE
docs: add agent contribution guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# Agent Contribution Contract
+
+This repository ships firmware for the M5Stack Tab5 using ESP-IDF and LVGL.  
+Follow the rules below whenever you make changes in this repo.
+
+## Commit & PR discipline
+- **Commit message format:** Use Conventional Commits: `type(scope): summary`.
+  - Allowed types: `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `build`, `ci`, `chore`.
+  - Keep the summary ≤ 72 characters, use imperative mood, and wrap body text at ≤ 72 characters per line.
+  - Reference issues in the footer (e.g., `Refs #123`).
+- **Small, reviewable PRs:**
+  - Keep each PR focused on a single feature or bugfix.
+  - Prefer ≤ ~500 lines of diff (adds + removals) per PR.
+  - Update docs/assets alongside code so reviewers see a complete change.
+  - Provide context in the PR description: what changed, why, and how it was verified (include screenshots/GIFs for UI changes).
+
+## Required checks before requesting review
+Run these from the repository root unless noted otherwise.
+
+| Command | When to run | Notes |
+| --- | --- | --- |
+| `idf.py set-target esp32p4` | First build in a fresh checkout | Only needed once per workspace unless you clean the build folder.
+| `idf.py build` | Every PR | Must succeed; catches most integration issues.
+| `idf.py clang-format` <br>or `clang-format -style=file -i <files>` | Whenever C/C++ is touched | Uses the repo's `.clang-format` (clang-format 13). Stage formatted files.
+| `idf.py lint` | When modifying components or build metadata | Ensures `idf_component.yml` metadata stays valid; safe to run even if no changes were made.
+| `ctags -R` / IDE index refresh | Optional but recommended | Keeps symbol navigation accurate after large refactors.
+
+If you add or modify scripts/tests in other languages, run the relevant linters (e.g., `python -m compileall` for Python, `npx markdownlint docs` for Markdown) and mention them in the PR.
+
+## Coding style & structure
+- Respect the project `.clang-format` for all C/C++/Obj-C files.
+- Match existing naming in the file you touch. Defaults:
+  - Classes/structs/interfaces: `PascalCase`.
+  - Member functions: `PascalCase`.
+  - Free/static functions: `snake_case` (mirrors existing helpers like `on_startup_anim`).
+  - Constants: `kPascalCase` for globals, `SCREAMING_SNAKE_CASE` for macros.
+- Keep includes grouped and ordered: standard library, third-party, then project headers. Let `clang-format` finalize spacing.
+- New firmware code lives under `custom/` (UI, integration, platform) unless you are patching upstream vendor code in `app/`.
+- Add SPDX headers to new source files to match the rest of the codebase.
+- Do not commit generated artifacts (build outputs, `.vscode`, etc.).
+
+---
+
+The instructions above apply to the entire repository unless a more specific `AGENTS.md` exists deeper in the tree.

--- a/custom/AGENTS.md
+++ b/custom/AGENTS.md
@@ -1,0 +1,22 @@
+# Custom Module Rules
+
+These rules apply to any files added under `custom/`.
+
+## Module layout
+- Mirror the existing structure when adding new features:
+  - `custom/ui/` for LVGL views and widgets.
+  - `custom/integration/` for Home Assistant, MQTT, or Frigate bindings.
+  - `custom/platform/` for device drivers, HAL glue, or power management.
+  - `custom/assets/` for RGB565 images, fonts, and other binary resources (pre-sized; no runtime scaling).
+- Keep module boundaries clean: UI files should not contain MQTT logic; use thin integration helpers instead.
+
+## Coding style
+- Place public declarations in `*.h` and implementation in matching `*.cpp` unless the file is header-only for performance.
+- Wrap new code in a descriptive namespace (e.g., `custom::ui`) to avoid collisions with upstream vendor code.
+- Use `snake_case` for free helper functions and file-scope statics, `PascalCase` for classes/structs, and `kPascalCase` for constants.
+- Include SPDX license headers at the top of every new file.
+- Run `idf.py build` after adding assets to ensure they are referenced correctly in CMake component files.
+
+## Assets
+- Store assets in `RGB565` (little-endian) format at the exact resolution required by the UI.
+- Update any asset manifest or registration tables when adding/removing files, and describe the change in the PR summary.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,10 @@
+# Documentation Rules
+
+These instructions apply to files under `docs/`.
+
+- Keep Markdown headings consistent with the existing documents (title case for H1, sentence case for deeper levels).
+- Wrap lines at ≤ 100 characters where practical to keep diffs reviewable.
+- Use relative links (`[text](./other_doc.md)`) so the files render correctly both on GitHub and inside firmware tooling.
+- When you adjust wireframes or design tokens, call out the change in the PR description so UI contributors can sync their work.
+- Include updated screenshots/mockups if the document describes UI that changed.
+- After editing Markdown, run `npx markdownlint docs` (or another Markdown linter) and fix reported issues before committing.


### PR DESCRIPTION
## Summary
- add a repository-wide `AGENTS.md` that documents commit, PR, and testing expectations
- add documentation-specific contribution rules under `docs/`
- define contribution structure for future modules under `custom/`

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c90fac29f08324b5b4fe152063f4e8