### PR TITLE
Add placeholder READMEs for custom module directories

### DIFF
--- a/custom/assets/README.md
+++ b/custom/assets/README.md
@@ -1,0 +1,3 @@
+# Custom Assets
+
+Store project-specific assets such as icons, backgrounds, fonts, and other binary resources in this directory.

--- a/custom/integration/README.md
+++ b/custom/integration/README.md
@@ -1,0 +1,3 @@
+# Integration Layer
+
+Use this folder for glue code that connects the Tab5 firmware to Home Assistant, MQTT, Frigate, and other external services.

--- a/custom/platform/README.md
+++ b/custom/platform/README.md
@@ -1,0 +1,3 @@
+# Platform Abstractions
+
+Place hardware-facing drivers and platform helpers here, including display, input, audio, and power management layers specific to the Tab5.

--- a/custom/ui/README.md
+++ b/custom/ui/README.md
@@ -1,0 +1,3 @@
+# Custom UI Modules
+
+This directory is reserved for LVGL screen layouts, widgets, and other user interface modules tailored for the Tab5 home control experience.


### PR DESCRIPTION
## Summary
- add placeholder README files under `custom/ui`, `custom/integration`, `custom/platform`, and `custom/assets` so the directories are kept in version control

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c90fad386c8324af945349a60bd9cf