### PR TITLE
Add ESP-IDF devcontainer and CI build workflow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  "name": "M5Tab5 ESP-IDF 5.x",
+  "image": "espressif/idf:release-v5.1",
+  "containerEnv": {
+    "IDF_TARGET": "esp32p4"
+  },
+  "runArgs": [
+    "--privileged",
+    "--device=/dev/ttyUSB0",
+    "--device=/dev/ttyACM0"
+  ],
+  "postCreateCommand": "python3 fetch_repos.py",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "espressif.esp-idf-extension",
+        "ms-python.python",
+        "ms-vscode.cpptools"
+      ],
+      "settings": {
+        "idf.espIdfPath": "/opt/esp/idf",
+        "idf.pythonBinPath": "/usr/bin/python3",
+        "idf.toolsPath": "/opt/esp"
+      }
+    }
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build Firmware
+
+on:
+  push:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+jobs:
+  esp-idf-build:
+    name: Build ESP-IDF project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build firmware
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: release-v5.1
+          target: esp32p4
+          command: python3 fetch_repos.py && idf.py build
+      - name: Upload firmware artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-${{ github.sha }}
+          path: |
+            build/*.bin
+            build/*.elf
+            build/*.map
+            build/flasher_args.json
+            build/bootloader/bootloader.bin
+            build/partition_table/partition-table.bin
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- add a VS Code devcontainer that uses the ESP-IDF 5.1 image, preconfigures the esp32p4 target, and installs common IDE extensions
- introduce a GitHub Actions workflow that builds the firmware with Espressif's esp-idf-ci-action and uploads the resulting binaries

## Testing
- `./bin/act push` *(fails: Docker is unavailable in the local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c90fae786483249216d4618cca57e4