### PR TITLE
docs: add ai dev preparation guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ This project extends the official [M5Tab5 User Demo](https://docs.m5stack.com/en
 ## Design & Docs
 
 Links to key design and documentation resources:
-- [`docs/TASKS.md`](docs/TASKS.md)
-- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
-- [`docs/ASSETS.md`](docs/ASSETS.md)
+- [`docs/TASKS.md`](docs/TASKS.md): prioritized roadmap for milestone planning.
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md): firmware structure and runtime data flow.
+- [`docs/ASSETS.md`](docs/ASSETS.md): asset pipeline expectations and QA checklist.
+- [`docs/AI_GUIDELINES.md`](docs/AI_GUIDELINES.md): workflow rules for AI-driven contributions.
 
 - **First Page: Default Demo for Tab5**
 The default user demo for testing out Tab5 features & control.

--- a/docs/AI_GUIDELINES.md
+++ b/docs/AI_GUIDELINES.md
@@ -1,0 +1,56 @@
+# AI Execution Guidelines
+
+Read this checklist before using an AI coding assistant on the project. It
+complements `docs/AI_Codex_Guide.md` by describing the workflow expectations,
+safety rails, and formatting rules for automated contributions.
+
+## Orientation steps
+
+1. Re-read `docs/wireframes.md` and confirm the screen or component you plan to
+   modify.
+2. Scan `docs/TASKS.md` to pick the highest-priority open task that matches your
+   scope.
+3. Inspect source files to understand naming conventions, namespaces, and
+   helper patterns.
+4. Record open questions in the pull request description or inline TODOs so a
+   human reviewer can resolve them.
+
+## Implementation playbook
+
+- Modify only the files required for the chosen task; avoid shotgun refactors.
+- Prefer extending `custom/` modules over editing vendor code in `app/` unless
+  the task explicitly requires it.
+- Maintain optimistic UI interactions with clear rollback paths when publishing
+  MQTT commands.
+- Reuse theme tokens from `ui_theme.h` and shared components from `custom/ui/`
+  to keep screens consistent.
+- When adding new assets or configuration values, update the relevant
+  documentation (`docs/ASSETS.md`, `docs/ARCHITECTURE.md`, or `README.md`).
+
+## Testing expectations
+
+- Run `idf.py build` before finalizing a change. Resolve compiler warnings
+  rather than silencing them.
+- Execute `idf.py lint` when modifying integration metadata or component
+  manifests.
+- Run `npx markdownlint docs` after editing Markdown. Fix or justify any
+  violations in the PR notes.
+- Capture on-device footage or simulator screenshots for UI-heavy changes and
+  attach them to the PR.
+
+## Commit hygiene
+
+- Use Conventional Commit messages as described in the repository `AGENTS.md`.
+- Keep commits focused. If the AI generates a broad refactor, split the work
+  manually before submitting a PR.
+- Document limitations or follow-up ideas in the PR description under a "Next
+  steps" heading.
+
+## Escalation rules
+
+- If a task conflicts with performance limits or design tokens, update the docs
+  first, then land the code change in a follow-up PR.
+- When encountering unclear MQTT payloads or stream behaviors, extend the
+  contract in `docs/MQTT_CONTRACT.md` and flag the ambiguity in the roadmap.
+- Avoid introducing new third-party dependencies without explicit human
+  approval.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,70 @@
+# Architecture Overview
+
+This document describes how the custom Tab5 firmware is structured so
+contributors can extend it without breaking modular boundaries or performance
+assumptions.
+
+## System boundaries
+
+- **Hardware**: M5Stack Tab5 (ESP32-P4, GT911 touch, ES8388 audio codec, IPS LCD
+  1280×720).
+- **Frameworks**: ESP-IDF 5.x for runtime, LVGL for UI composition, MQTT for
+  Home Assistant connectivity.
+- **Upstream code**: The base demo from M5Stack lives under `app/`; custom
+  features must reside in `custom/` to keep merges with upstream simple.
+
+## Firmware layout
+
+- `custom/ui/`: screen implementations, shared widgets, and theme tokens.
+- `custom/integration/`: MQTT, Home Assistant, and Frigate bindings plus mock
+  providers.
+- `custom/platform/`: display init, touch, audio, power management, and
+  diagnostics.
+- `custom/assets/`: RGB565 images, fonts, and other binary resources registered
+  with LVGL.
+- `docs/`: source-of-truth specifications for layout, tokens, contracts, and AI
+  workflows.
+
+Place cross-cutting utilities (logging helpers, configuration structs) in their
+own subdirectory under `custom/` so they can be reused without polluting vendor
+code.
+
+## Runtime architecture
+
+1. **Boot sequence**: `app_main` initializes ESP-IDF services, then calls into
+   `custom::platform` to configure display buffers, touch, Wi-Fi, and the audio
+   codec.
+2. **UI bring-up**: `custom::ui::Init()` registers styles from `ui_theme.h`,
+   builds persistent LVGL objects for each screen, and wires navigation events.
+3. **Data bindings**: integration modules expose observer APIs that push state
+   updates into the UI. UI interactions trigger command helpers that publish
+   MQTT messages with optimistic feedback and rollback timers.
+4. **Background services**: tasks under `custom::integration` manage MQTT
+   sessions, Frigate stream lifecycles, and diagnostic telemetry. They
+   communicate via queues or LVGL-safe callbacks to respect threading
+   constraints.
+
+## Configuration and secrets
+
+- Store device credentials in NVS by default. Provide menuconfig options for
+  initial provisioning but avoid hard-coding secrets in source control.
+- Collect feature flags (mock data mode, diagnostics overlay, stream fallback
+  overrides) in a shared configuration header so UI and integration code stay
+  aligned.
+
+## Performance considerations
+
+- Follow the budgets listed in `docs/PERFORMANCE.md`. Create LVGL objects for
+  all primary screens at startup to avoid heap churn during navigation.
+- Use double-buffered rendering with carefully sized draw buffers (≤6 MB) and
+  reuse animation timelines rather than re-creating them per interaction.
+- Throttle background MQTT or Frigate work when the UI reports frame drops.
+
+## Testing hooks
+
+- Wrap MQTT access behind an abstraction so integration tests can swap in an
+  in-memory broker.
+- Expose metrics (FPS, heap, MQTT round-trip) through the diagnostics overlay to
+  support manual and automated verification.
+- Keep `idf.py build`, `idf.py lint`, and `npx markdownlint docs` passing before
+  opening a PR.

--- a/docs/ASSETS.md
+++ b/docs/ASSETS.md
@@ -1,0 +1,53 @@
+# Asset Pipeline
+
+Use this checklist when creating or updating visual and audio assets so the
+firmware keeps a small footprint and renders crisply on the Tab5 display.
+
+## File organization
+
+- Store production-ready assets in `custom/assets/`. Keep source design files
+  (Figma, PSD) out of the repository; attach them to design tickets instead.
+- Group assets by usage: `icons/`, `images/`, `backgrounds/`, `fonts/`, and add
+  screen-specific subfolders when helpful.
+- Document new assets in the table below so AI agents know which files already
+  exist.
+
+| File | Purpose | Notes |
+| --- | --- | --- |
+| _TBD_ | Populate as assets are created. | Include resolution, depth, owner. |
+
+## Export settings
+
+- Color format: **RGB565 little-endian** (LVGL friendly) with no alpha channel.
+- Dimensions: match the final on-screen size; avoid runtime scaling to preserve
+  performance.
+- Naming: lowercase with dashes, e.g., `icon-lights-rgb565.bin`. Include the
+  color depth suffix when ambiguous.
+- Optimize assets using `lvgl_img_conv.py` or `ImageMagick` scripts before
+  committing.
+
+## Registration in code
+
+- Reference new binaries in the relevant `CMakeLists.txt` within `custom/` so
+  they are flashed with the firmware.
+- Register LVGL image descriptors in a central header (e.g.,
+  `custom/assets/assets.h`) to keep lookups consistent. Add forward declarations
+  instead of duplicating descriptors across screens.
+- Update `README.md` or per-screen documentation when a new asset changes the
+  visual spec.
+
+## Accessibility and localization
+
+- Prefer icons with clear silhouettes that remain legible at 56×56 px touch
+  targets.
+- Provide alternative text descriptions in UI code to support future
+  text-to-speech or analytics.
+- When adding text baked into images, create localized variants or avoid
+  rasterized text entirely.
+
+## Quality assurance checklist
+
+- [ ] Asset file passes LVGL image converter validation with no warnings.
+- [ ] Asset referenced in code builds successfully on hardware.
+- [ ] Visual inspection on device confirms sharp edges and accurate colors.
+- [ ] Documentation updated (this file and any affected screen specs).

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,0 +1,123 @@
+# Task Roadmap
+
+This roadmap sequences the work required to transform the stock M5Stack Tab5
+demo into the Home Assistant control experience described in the wireframes. It
+is written so humans and AI assistants can pick up a task, understand
+prerequisites, and deliver a focused change.
+
+## How to work through the backlog
+
+- Start at the top of the milestone that is currently in progress.
+- Break tasks into pull requests that stay below ~500 lines of diff.
+- Keep documentation and source code changes in the same pull request when they
+  are related.
+- Update the status marker when a task is handed off between contributors.
+- When a task exposes new constraints, add notes in the handoff bullet and
+  mirror key findings in `docs/AI_Codex_Guide.md` or `docs/wireframes.md`.
+
+## Milestones and tasks
+
+### Milestone 0 — Foundations
+
+- **M0.1 — Toolchain smoke test** (status: ☐)
+  - Dependencies: none.
+  - Outcome: confirm `idf.py build` succeeds before any modifications.
+  - Considerations: capture environment quirks in `README.md`.
+- **M0.2 — Credential strategy** (status: ☐)
+  - Dependencies: M0.1.
+  - Outcome: document how Wi-Fi, MQTT, and Assist credentials are stored (NVS vs
+    compile time).
+  - Considerations: update `docs/ARCHITECTURE.md` with the decision.
+- **M0.3 — Mock providers** (status: ☐)
+  - Dependencies: M0.1.
+  - Outcome: add mock data sources for Home, Rooms, and Security screens under
+    `custom/integration/` behind a build flag.
+  - Considerations: unblock UI work while MQTT is offline.
+
+### Milestone 1 — UI skeleton
+
+- **M1.1 — Screen scaffolding** (status: ☐)
+  - Dependencies: M0.3.
+  - Outcome: create persistent LVGL objects for `ui_home.*`, `ui_rooms.*`,
+    `ui_security.*`, and `ui_control_center.*` that match the layout spec.
+  - Considerations: reuse placeholder widgets from `custom/ui/ui_components.*`.
+- **M1.2 — Shared components** (status: ☐)
+  - Dependencies: M1.1.
+  - Outcome: implement cards, chips, sliders, tabs, and confirm sheets styled
+    via `ui_theme.h`.
+  - Considerations: centralize styles so future screens stay consistent.
+- **M1.3 — Navigation and gestures** (status: ☐)
+  - Dependencies: M1.1.
+  - Outcome: wire the tab rail, edge swipes, and control center sheet
+    interactions.
+  - Considerations: include optimistic animations for taps and long presses.
+
+### Milestone 2 — Feature scaffolding
+
+- **M2.1 — Home bindings** (status: ☐)
+  - Dependencies: M1.2.
+  - Outcome: connect Home cards to mock providers with optimistic updates ready
+    for MQTT swap.
+  - Considerations: keep command helpers in `custom/integration/`.
+- **M2.2 — Rooms interactions** (status: ☐)
+  - Dependencies: M1.2.
+  - Outcome: implement room detail updates, two-finger swipe navigation, and
+    long-press sheets.
+  - Considerations: validate gestures on hardware for reliability.
+- **M2.3 — Security carousel** (status: ☐)
+  - Dependencies: M1.2.
+  - Outcome: build the camera carousel and event chips backed by mock Frigate
+    data.
+  - Considerations: respect the HLS → MJPEG → snapshot fallback described in
+    the AI guide.
+
+### Milestone 3 — Home Assistant integration
+
+- **M3.1 — MQTT for Home and Rooms** (status: ☐)
+  - Dependencies: M2.1 and M2.2.
+  - Outcome: replace mock providers with real MQTT subscriptions and publish
+    helpers.
+  - Considerations: extend `docs/MQTT_CONTRACT.md` with payload schemas.
+- **M3.2 — Frigate live view** (status: ☐)
+  - Dependencies: M2.3.
+  - Outcome: stream live video with fallback handling and update the event
+    timeline from Frigate.
+  - Considerations: measure frame times against `docs/PERFORMANCE.md`.
+- **M3.3 — Control center commands** (status: ☐)
+  - Dependencies: M2.1.
+  - Outcome: publish brightness, volume, and toggle commands with rollback
+    timers.
+  - Considerations: log failures for debugging and expose status to the UI.
+
+### Milestone 4 — Quality and automation
+
+- **M4.1 — Diagnostics overlay** (status: ☐)
+  - Dependencies: M3.1 through M3.3.
+  - Outcome: surface FPS, heap usage, and LVGL draw time behind a debug toggle.
+  - Considerations: explain activation steps in `README.md`.
+- **M4.2 — Hardware regression suite** (status: ☐)
+  - Dependencies: M3.x series tasks.
+  - Outcome: create a smoke-test script or CI workflow that exercises MQTT
+    flows and key UI paths.
+  - Considerations: share setup instructions alongside the script.
+
+Status legend: ☐ pending, ☐⚙ in progress, ☑ done.
+
+## Definition of done reminders
+
+- Match layout and tokens defined in `docs/wireframes.md` and
+  `custom/ui/ui_theme.h`.
+- Route telemetry and commands through helpers in `custom/integration/` (no
+  broker logic in UI files).
+- Run the build and lint commands listed in the root `AGENTS.md` before
+  requesting review.
+- Update README and relevant docs with new capabilities or constraints.
+
+## Coordination tips
+
+- Reserve feature branches or issues before starting large tasks to avoid
+  overlap.
+- Attach demo photos or short videos to pull requests so reviewers can evaluate
+  animations.
+- When handing off partially complete work, link the working branch and
+  summarize progress here.


### PR DESCRIPTION
## Summary
- add a living task roadmap so humans and AI contributors can sequence work
- document firmware architecture, asset workflow, and AI execution guardrails for Codex-style agents
- update the README doc index to link to the new guidance with short descriptions

## Testing
- npx --yes markdownlint-cli docs/TASKS.md docs/ARCHITECTURE.md docs/ASSETS.md docs/AI_GUIDELINES.md

------
https://chatgpt.com/codex/tasks/task_e_68c918f08ddc8324841818dddc5f8f58