### PR TITLE
fix: include cstring for wifi softap

### DIFF
--- a/platforms/tab5/main/hal/components/hal_wifi.cpp
+++ b/platforms/tab5/main/hal/components/hal_wifi.cpp
@@ -7,7 +7,7 @@
 #include <mooncake_log.h>
 #include <vector>
 #include <memory>
-#include <string.h>
+#include <cstring>
 #include <bsp/m5stack_tab5.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/event_groups.h>


### PR DESCRIPTION
## Summary
- include the C++ `<cstring>` header before using `std::strncpy` and `std::strlen`
- unblocks building the Wi-Fi softAP HAL with the newer ESP-IDF toolchain

## Testing
- not run (idf.py is not available in the provided environment)

------
https://chatgpt.com/codex/tasks/task_e_68ca5beaf9948324b787b91fb5637925