### PR TITLE
fix: use NG I2C panel IO for GT911 touch

### DIFF
--- a/platforms/tab5/components/m5stack_tab5/m5stack_tab5.c
+++ b/platforms/tab5/components/m5stack_tab5/m5stack_tab5.c
@@ -1489,7 +1489,7 @@ esp_err_t bsp_touch_new(const bsp_touch_config_t* config, esp_lcd_touch_handle_t
     esp_lcd_panel_io_i2c_config_t tp_io_config = ESP_LCD_TOUCH_IO_I2C_GT911_CONFIG();
     tp_io_config.dev_addr                      = ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS_BACKUP;  // 更改 GT911 地址
     tp_io_config.scl_speed_hz                  = CONFIG_BSP_I2C_CLK_SPEED_HZ;
-    ESP_RETURN_ON_ERROR(esp_lcd_new_panel_io_i2c(i2c_handle, &tp_io_config, &tp_io_handle), TAG, "");
+    ESP_RETURN_ON_ERROR(esp_lcd_new_panel_io_i2c_v2(i2c_handle, &tp_io_config, &tp_io_handle), TAG, "");
     return esp_lcd_touch_new_i2c_gt911(tp_io_handle, &tp_cfg, ret_touch);
 }
 


### PR DESCRIPTION
## Summary
- switch the GT911 touch initialization to esp_lcd_new_panel_io_i2c_v2 so it stays on the NG I2C driver path

## Testing
- idf.py build *(fails: idf.py not found in container)*
- idf.py clang-format *(fails: idf.py not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7176997c8324b1aa5d7142140e8c