### PR TITLE
Add script to detect legacy I2C usage

### DIFF
--- a/scripts/check_legacy_i2c.py
+++ b/scripts/check_legacy_i2c.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Detect legacy ESP-IDF I2C driver usage in the source tree.
+
+This script scans the repository for includes of ``driver/i2c.h`` and for calls
+to helpers that belong to the deprecated "legacy" I2C driver. Mixing those
+helpers with the NG driver will trigger runtime conflicts on firmware boot, so
+CI blocks them from landing in ``main``.
+
+Run the script from the repository root::
+
+    python3 scripts/check_legacy_i2c.py
+
+The exit status is non-zero when a forbidden pattern is found, making it easy
+to wire the script into pre-commit hooks or CI jobs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class LegacyPattern:
+    """Representation of a legacy usage that should be flagged."""
+
+    regex: re.Pattern[str]
+    description: str
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A single match of a legacy API usage."""
+
+    path: Path
+    line_no: int
+    reason: str
+    line: str
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    """Aggregated result of scanning one or more paths."""
+
+    files_scanned: int
+    findings: list[Finding]
+
+
+SOURCE_SUFFIXES: frozenset[str] = frozenset(
+    {
+        ".c",
+        ".cc",
+        ".cpp",
+        ".cxx",
+        ".h",
+        ".hh",
+        ".hpp",
+        ".hxx",
+        ".ipp",
+    }
+)
+
+EXCLUDED_DIRS: frozenset[str] = frozenset(
+    {
+        ".git",
+        "build",
+        "cmake-build-debug",
+        "cmake-build-release",
+        "managed_components",
+        "__pycache__",
+        ".venv",
+    }
+)
+
+LEGACY_PATTERNS: tuple[LegacyPattern, ...] = (
+    LegacyPattern(
+        re.compile(r"#\s*include\s*[\"<]driver/i2c\.h[\">]"),
+        "legacy driver include",
+    ),
+    LegacyPattern(
+        re.compile(r"\bi2c_param_config\b"),
+        "legacy i2c_param_config helper",
+    ),
+    LegacyPattern(
+        re.compile(r"\bi2c_driver_install\b"),
+        "legacy i2c_driver_install helper",
+    ),
+    LegacyPattern(
+        re.compile(r"\bi2c_driver_delete\b"),
+        "legacy i2c_driver_delete helper",
+    ),
+    LegacyPattern(
+        re.compile(r"\bi2c_cmd_link_create(?:_static)?\b"),
+        "legacy I2C command link creation",
+    ),
+    LegacyPattern(
+        re.compile(r"\bi2c_cmd_link_delete(?:_static)?\b"),
+        "legacy I2C command link deletion",
+    ),
+    LegacyPattern(
+        re.compile(r"\bi2c_master_cmd_begin\b"),
+        "legacy i2c_master_cmd_begin helper",
+    ),
+    LegacyPattern(
+        re.compile(r"\bi2c_master_(?:start|stop|write_byte|write|read_byte|read)\b"),
+        "legacy low-level I2C master helper",
+    ),
+)
+
+
+def iter_source_files(
+    paths: Sequence[Path],
+    *,
+    include_suffixes: Iterable[str] = SOURCE_SUFFIXES,
+    excluded_dirs: Iterable[str] = EXCLUDED_DIRS,
+) -> Iterator[Path]:
+    """Yield source files below *paths* that match the allowed suffixes."""
+
+    suffixes = {suffix.lower() for suffix in include_suffixes}
+    exclude = set(excluded_dirs)
+
+    for base in paths:
+        if base.is_file():
+            if base.suffix.lower() in suffixes:
+                yield base
+            continue
+
+        for dirpath, dirnames, filenames in os.walk(base, followlinks=False):
+            dirnames[:] = [d for d in dirnames if d not in exclude]
+            for filename in filenames:
+                path = Path(dirpath, filename)
+                if path.suffix.lower() in suffixes:
+                    yield path
+
+
+def scan_file(path: Path, patterns: Sequence[LegacyPattern] = LEGACY_PATTERNS) -> list[Finding]:
+    """Return a list of legacy usage matches for *path*."""
+
+    matches: list[Finding] = []
+    with path.open("r", encoding="utf-8", errors="ignore") as handle:
+        for line_no, line in enumerate(handle, start=1):
+            for pattern in patterns:
+                if pattern.regex.search(line):
+                    matches.append(
+                        Finding(
+                            path=path,
+                            line_no=line_no,
+                            reason=pattern.description,
+                            line=line.rstrip(),
+                        )
+                    )
+    return matches
+
+
+def scan_paths(paths: Sequence[Path]) -> ScanResult:
+    """Scan the provided *paths* for legacy I2C usage."""
+
+    findings: list[Finding] = []
+    files_scanned = 0
+
+    for file_path in iter_source_files(paths):
+        files_scanned += 1
+        findings.extend(scan_file(file_path))
+
+    return ScanResult(files_scanned=files_scanned, findings=findings)
+
+
+def _format_finding(finding: Finding, root: Path) -> str:
+    relative_path = finding.path.resolve().relative_to(root)
+    return (
+        f"{relative_path}:{finding.line_no}: {finding.reason}\n"
+        f"    {finding.line}"
+    )
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[REPO_ROOT],
+        help="Paths to scan (defaults to the repository root).",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Root used when reporting relative file paths.",
+    )
+
+    args = parser.parse_args(argv)
+    target_paths = [path if path.is_absolute() else args.root / path for path in args.paths]
+
+    result = scan_paths(target_paths)
+
+    if result.findings:
+        print(f"Found {len(result.findings)} legacy I2C usage(s) across {result.files_scanned} file(s):")
+        for finding in result.findings:
+            print(_format_finding(finding, args.root.resolve()))
+        return 1
+
+    print(f"No legacy I2C usage found in {result.files_scanned} file(s).")
+    return 0
+
+
+def main() -> None:  # pragma: no cover - thin CLI wrapper
+    sys.exit(run())
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_check_legacy_i2c.py
+++ b/tests/test_check_legacy_i2c.py
@@ -1,0 +1,83 @@
+"""Tests for the legacy I2C detection helper."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import sys
+import unittest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "check_legacy_i2c.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_legacy_i2c", MODULE_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - sanity guard
+        raise RuntimeError("Unable to load check_legacy_i2c module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class CheckLegacyI2CTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module = _load_module()
+
+    def test_detects_legacy_include(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            src_path = Path(tmpdir) / "legacy.c"
+            src_path.write_text('#include "driver/i2c.h"\n', encoding="utf-8")
+
+            result = self.module.scan_paths([Path(tmpdir)])
+
+            self.assertEqual(result.files_scanned, 1)
+            self.assertEqual(len(result.findings), 1)
+            finding = result.findings[0]
+            self.assertEqual(finding.path, src_path)
+            self.assertIn("legacy driver include", finding.reason)
+
+    def test_allows_ng_driver_helpers(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            src_path = Path(tmpdir) / "ng_driver.c"
+            src_path.write_text(
+                (
+                    '#include "driver/i2c_master.h"\n'
+                    "void init_bus(void) {\n"
+                    "    i2c_master_bus_add_device(0, 0, 0);\n"
+                    "}\n"
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.module.scan_paths([Path(tmpdir)])
+
+            self.assertEqual(result.files_scanned, 1)
+            self.assertFalse(result.findings)
+
+    def test_detects_legacy_helpers(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            src_path = Path(tmpdir) / "legacy_helpers.c"
+            src_path.write_text(
+                (
+                    "#include \"driver/i2c_master.h\"\n"
+                    "void start(void) {\n"
+                    "    i2c_master_cmd_begin(0, 0, 0);\n"
+                    "}\n"
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.module.scan_paths([Path(tmpdir)])
+
+            self.assertEqual(result.files_scanned, 1)
+            self.assertEqual(len(result.findings), 1)
+            finding = result.findings[0]
+            self.assertIn("legacy i2c_master_cmd_begin", finding.reason)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Python helper that scans source files for includes or functions from the legacy ESP-IDF I2C driver
- add unit coverage to exercise the scanner against legacy and NG driver usage patterns

## Testing
- python3 -m unittest discover -s tests
- python3 scripts/check_legacy_i2c.py

------
https://chatgpt.com/codex/tasks/task_e_68ca7701da388324992274369afa80b0