### PR TITLE
chore(release): cut 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.0.1 (2025-09-17)
+
+### Fixes
+
+* **i2c:** use NG touch panel IO to keep GT911 working after flashes ([fc3e861](https://github.com/baba-dev/M5Tab5-UserDemo/commit/fc3e861203b86a23a1e9f1055bb0af16f8eb7018))
+
+### Build
+
+* **devcontainer:** adopt the espressif/idf base image and auto-load tools with helper scripts ([d43c6cc](https://github.com/baba-dev/M5Tab5-UserDemo/commit/d43c6cc207187a275ada29055cca8e0c140935e2))
+
+### Tests
+
+* add coverage to detect legacy I²C driver usage in downstream components ([b470ce3](https://github.com/baba-dev/M5Tab5-UserDemo/commit/b470ce39975ec986e459a1e4695c3722e5dae25d))
+
 ## 1.0.0 (2025-09-17)
 
 

--- a/app/apps/app_startup_anim/app_startup_anim.cpp
+++ b/app/apps/app_startup_anim/app_startup_anim.cpp
@@ -13,7 +13,7 @@ using namespace mooncake;
 using namespace smooth_ui_toolkit;
 using namespace smooth_ui_toolkit::lvgl_cpp;
 
-#define FIRMWARE_VERSION "V0.2"
+#define FIRMWARE_VERSION "V1.0.1"
 
 AppStartupAnim::AppStartupAnim()
 {


### PR DESCRIPTION
## Summary
- add release notes for v1.0.1 and capture the I2C, devcontainer, and regression testing updates
- bump the startup animation banner to display firmware version V1.0.1

## Testing
- `idf.py set-target esp32p4` *(fails: command not found in container)*
- `idf.py build` *(not run: idf.py unavailable in container image)*
- `npx markdownlint CHANGELOG.md` *(fails: npm cannot determine executable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caa0befaa4832481165355b5b1e158