### PR TITLE
feat(ui): add left nav rail with 5 tabs and empty pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,13 @@ Links to key design and documentation resources:
 - [`docs/ASSETS.md`](docs/ASSETS.md): asset pipeline expectations and QA checklist.
 - [`docs/AI_GUIDELINES.md`](docs/AI_GUIDELINES.md): workflow rules for AI-driven contributions.
 
+- **Navigation Rail Preview**
+  - Persistent left rail with icon buttons for ESP32P4 demo, Rooms, Frigate Security, Local Climate Station, and TV Controls.
+  - Tap a destination to reveal a full-bleed wallpaper page; backgrounds rotate between `custom/assets/bg/1.png` and `custom/assets/bg/2.png` every 30 seconds.
+  - Cards, buttons, and title bars share softened 16 px radii and shadows to match the hardware aesthetic.
+
 - **First Page: Default Demo for Tab5**
-The default user demo for testing out Tab5 features & control.
+  The default user demo for testing out Tab5 features & control.
 
 - **Second Page: Landscape-first dashboard (1280×720)**  
   At-a-glance view of lights, climate, security, and media from Home Assistant.

--- a/app/apps/app_launcher/view/view.cpp
+++ b/app/apps/app_launcher/view/view.cpp
@@ -11,6 +11,7 @@
 #include <smooth_ui_toolkit.h>
 #include <smooth_lvgl.h>
 #include <apps/utils/audio/audio.h>
+#include "custom/ui/ui_root.h"
 
 using namespace launcher_view;
 using namespace smooth_ui_toolkit;
@@ -55,6 +56,12 @@ void LauncherView::init()
     for (auto& panel : _panels) {
         panel->init();
     }
+
+    if (_ui_root != nullptr) {
+        ui_root_destroy(_ui_root);
+        _ui_root = nullptr;
+    }
+    _ui_root = ui_root_create();
 }
 
 void LauncherView::update()
@@ -63,5 +70,13 @@ void LauncherView::update()
 
     for (auto& panel : _panels) {
         panel->update(_is_stacked);
+    }
+}
+
+LauncherView::~LauncherView()
+{
+    if (_ui_root != nullptr) {
+        ui_root_destroy(_ui_root);
+        _ui_root = nullptr;
     }
 }

--- a/app/apps/app_launcher/view/view.h
+++ b/app/apps/app_launcher/view/view.h
@@ -12,6 +12,8 @@
 #include <smooth_lvgl.h>
 #include <vector>
 
+struct ui_root_t;
+
 namespace launcher_view {
 
 /**
@@ -291,11 +293,13 @@ class LauncherView {
 public:
     void init();
     void update();
+    ~LauncherView();
 
 private:
     bool _is_stacked = false;
     std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image> _img_bg;
     std::vector<std::unique_ptr<PanelBase>> _panels;
+    ui_root_t *_ui_root = nullptr;
 
     void update_anim();
 };

--- a/custom/assets/bg/bg_images.c
+++ b/custom/assets/bg/bg_images.c
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d02d14fb0cad699baef1c034eb847a1911665aace8174b88f1de27e9eeba42a7
+size 22666838

--- a/custom/assets/bg/bg_images.h
+++ b/custom/assets/bg/bg_images.h
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f3dd79971bd7a141f2b4df7b8bcb10b403dc0943513c1f4b486da3b3d7fd8e8
+size 454

--- a/custom/ui/pages/ui_page_cctv.c
+++ b/custom/ui/pages/ui_page_cctv.c
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include "ui_page_cctv.h"
+
+#include "ui_wallpaper.h"
+
+static void ui_page_cctv_delete_cb(lv_event_t *event)
+{
+    ui_wallpaper_t *wallpaper = (ui_wallpaper_t *)lv_event_get_user_data(event);
+    ui_wallpaper_detach(wallpaper);
+}
+
+static lv_obj_t *ui_page_create_content(lv_obj_t *page, const char *title_text)
+{
+    lv_obj_t *content = lv_obj_create(page);
+    lv_obj_remove_style_all(content);
+    lv_obj_set_size(content, LV_PCT(100), LV_PCT(100));
+    lv_obj_set_style_bg_opa(content, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_style_pad_left(content, 192, LV_PART_MAIN);
+    lv_obj_set_style_pad_right(content, 48, LV_PART_MAIN);
+    lv_obj_set_style_pad_top(content, 40, LV_PART_MAIN);
+    lv_obj_set_style_pad_bottom(content, 40, LV_PART_MAIN);
+    lv_obj_set_style_pad_row(content, 32, LV_PART_MAIN);
+    lv_obj_set_flex_flow(content, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(content, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+
+    lv_obj_t *title = lv_obj_create(content);
+    lv_obj_remove_style_all(title);
+    lv_obj_set_width(title, LV_PCT(100));
+    lv_obj_set_style_bg_color(title, lv_color_hex(0x141e28), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(title, LV_OPA_78, LV_PART_MAIN);
+    lv_obj_set_style_radius(title, 16, LV_PART_MAIN);
+    lv_obj_set_style_shadow_width(title, 24, LV_PART_MAIN);
+    lv_obj_set_style_shadow_opa(title, LV_OPA_50, LV_PART_MAIN);
+    lv_obj_set_style_shadow_ofs_y(title, 10, LV_PART_MAIN);
+    lv_obj_set_style_border_width(title, 0, LV_PART_MAIN);
+    lv_obj_set_style_pad_all(title, 28, LV_PART_MAIN);
+
+    lv_obj_t *label = lv_label_create(title);
+    lv_label_set_text(label, title_text);
+    lv_obj_set_width(label, LV_PCT(100));
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN);
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_32, LV_PART_MAIN);
+    lv_obj_set_style_text_color(label, lv_color_hex(0xf1f5f9), LV_PART_MAIN);
+
+    return content;
+}
+
+lv_obj_t *ui_page_cctv_create(lv_obj_t *parent)
+{
+    if (parent == NULL) {
+        return NULL;
+    }
+
+    lv_obj_t *page = lv_obj_create(parent);
+    lv_obj_remove_style_all(page);
+    lv_obj_set_size(page, LV_PCT(100), LV_PCT(100));
+    lv_obj_set_style_bg_opa(page, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_scroll_dir(page, LV_DIR_VER);
+    lv_obj_set_scrollbar_mode(page, LV_SCROLLBAR_MODE_OFF);
+    lv_obj_add_flag(page, LV_OBJ_FLAG_CLICKABLE);
+
+    ui_wallpaper_t *wallpaper = ui_wallpaper_attach(page);
+    if (wallpaper != NULL) {
+        lv_obj_add_event_cb(page, ui_page_cctv_delete_cb, LV_EVENT_DELETE, wallpaper);
+    }
+
+    ui_page_create_content(page, "Frigate Security");
+
+    return page;
+}

--- a/custom/ui/pages/ui_page_cctv.h
+++ b/custom/ui/pages/ui_page_cctv.h
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#pragma once
+
+#ifdef __has_include
+#if __has_include("lvgl.h")
+#ifndef LV_LVGL_H_INCLUDE_SIMPLE
+#define LV_LVGL_H_INCLUDE_SIMPLE
+#endif
+#endif
+#endif
+
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "lvgl/lvgl.h"
+#endif
+
+lv_obj_t *ui_page_cctv_create(lv_obj_t *parent);

--- a/custom/ui/pages/ui_page_media.c
+++ b/custom/ui/pages/ui_page_media.c
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include "ui_page_media.h"
+
+#include "ui_wallpaper.h"
+
+static void ui_page_media_delete_cb(lv_event_t *event)
+{
+    ui_wallpaper_t *wallpaper = (ui_wallpaper_t *)lv_event_get_user_data(event);
+    ui_wallpaper_detach(wallpaper);
+}
+
+static lv_obj_t *ui_page_create_content(lv_obj_t *page, const char *title_text)
+{
+    lv_obj_t *content = lv_obj_create(page);
+    lv_obj_remove_style_all(content);
+    lv_obj_set_size(content, LV_PCT(100), LV_PCT(100));
+    lv_obj_set_style_bg_opa(content, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_style_pad_left(content, 192, LV_PART_MAIN);
+    lv_obj_set_style_pad_right(content, 48, LV_PART_MAIN);
+    lv_obj_set_style_pad_top(content, 40, LV_PART_MAIN);
+    lv_obj_set_style_pad_bottom(content, 40, LV_PART_MAIN);
+    lv_obj_set_style_pad_row(content, 32, LV_PART_MAIN);
+    lv_obj_set_flex_flow(content, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(content, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+
+    lv_obj_t *title = lv_obj_create(content);
+    lv_obj_remove_style_all(title);
+    lv_obj_set_width(title, LV_PCT(100));
+    lv_obj_set_style_bg_color(title, lv_color_hex(0x171f2b), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(title, LV_OPA_80, LV_PART_MAIN);
+    lv_obj_set_style_radius(title, 16, LV_PART_MAIN);
+    lv_obj_set_style_shadow_width(title, 24, LV_PART_MAIN);
+    lv_obj_set_style_shadow_opa(title, LV_OPA_50, LV_PART_MAIN);
+    lv_obj_set_style_shadow_ofs_y(title, 10, LV_PART_MAIN);
+    lv_obj_set_style_border_width(title, 0, LV_PART_MAIN);
+    lv_obj_set_style_pad_all(title, 28, LV_PART_MAIN);
+
+    lv_obj_t *label = lv_label_create(title);
+    lv_label_set_text(label, title_text);
+    lv_obj_set_width(label, LV_PCT(100));
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN);
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_32, LV_PART_MAIN);
+    lv_obj_set_style_text_color(label, lv_color_hex(0xf8fafc), LV_PART_MAIN);
+
+    return content;
+}
+
+lv_obj_t *ui_page_media_create(lv_obj_t *parent)
+{
+    if (parent == NULL) {
+        return NULL;
+    }
+
+    lv_obj_t *page = lv_obj_create(parent);
+    lv_obj_remove_style_all(page);
+    lv_obj_set_size(page, LV_PCT(100), LV_PCT(100));
+    lv_obj_set_style_bg_opa(page, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_scroll_dir(page, LV_DIR_VER);
+    lv_obj_set_scrollbar_mode(page, LV_SCROLLBAR_MODE_OFF);
+    lv_obj_add_flag(page, LV_OBJ_FLAG_CLICKABLE);
+
+    ui_wallpaper_t *wallpaper = ui_wallpaper_attach(page);
+    if (wallpaper != NULL) {
+        lv_obj_add_event_cb(page, ui_page_media_delete_cb, LV_EVENT_DELETE, wallpaper);
+    }
+
+    ui_page_create_content(page, "TV Controls");
+
+    return page;
+}

--- a/custom/ui/pages/ui_page_media.h
+++ b/custom/ui/pages/ui_page_media.h
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#pragma once
+
+#ifdef __has_include
+#if __has_include("lvgl.h")
+#ifndef LV_LVGL_H_INCLUDE_SIMPLE
+#define LV_LVGL_H_INCLUDE_SIMPLE
+#endif
+#endif
+#endif
+
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "lvgl/lvgl.h"
+#endif
+
+lv_obj_t *ui_page_media_create(lv_obj_t *parent);

--- a/custom/ui/pages/ui_page_rooms.c
+++ b/custom/ui/pages/ui_page_rooms.c
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include "ui_page_rooms.h"
+
+#include "ui_wallpaper.h"
+
+static void ui_page_rooms_delete_cb(lv_event_t *event)
+{
+    ui_wallpaper_t *wallpaper = (ui_wallpaper_t *)lv_event_get_user_data(event);
+    ui_wallpaper_detach(wallpaper);
+}
+
+static lv_obj_t *ui_page_create_content(lv_obj_t *page, const char *title_text)
+{
+    lv_obj_t *content = lv_obj_create(page);
+    lv_obj_remove_style_all(content);
+    lv_obj_set_size(content, LV_PCT(100), LV_PCT(100));
+    lv_obj_set_style_bg_opa(content, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_style_pad_left(content, 192, LV_PART_MAIN);
+    lv_obj_set_style_pad_right(content, 48, LV_PART_MAIN);
+    lv_obj_set_style_pad_top(content, 40, LV_PART_MAIN);
+    lv_obj_set_style_pad_bottom(content, 40, LV_PART_MAIN);
+    lv_obj_set_style_pad_row(content, 32, LV_PART_MAIN);
+    lv_obj_set_flex_flow(content, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(content, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+
+    lv_obj_t *title = lv_obj_create(content);
+    lv_obj_remove_style_all(title);
+    lv_obj_set_width(title, LV_PCT(100));
+    lv_obj_set_style_bg_color(title, lv_color_hex(0x16202c), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(title, LV_OPA_80, LV_PART_MAIN);
+    lv_obj_set_style_radius(title, 16, LV_PART_MAIN);
+    lv_obj_set_style_shadow_width(title, 24, LV_PART_MAIN);
+    lv_obj_set_style_shadow_opa(title, LV_OPA_50, LV_PART_MAIN);
+    lv_obj_set_style_shadow_ofs_y(title, 10, LV_PART_MAIN);
+    lv_obj_set_style_border_width(title, 0, LV_PART_MAIN);
+    lv_obj_set_style_pad_all(title, 28, LV_PART_MAIN);
+
+    lv_obj_t *label = lv_label_create(title);
+    lv_label_set_text(label, title_text);
+    lv_obj_set_width(label, LV_PCT(100));
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN);
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_32, LV_PART_MAIN);
+    lv_obj_set_style_text_color(label, lv_color_hex(0xf8fafc), LV_PART_MAIN);
+
+    return content;
+}
+
+lv_obj_t *ui_page_rooms_create(lv_obj_t *parent)
+{
+    if (parent == NULL) {
+        return NULL;
+    }
+
+    lv_obj_t *page = lv_obj_create(parent);
+    lv_obj_remove_style_all(page);
+    lv_obj_set_size(page, LV_PCT(100), LV_PCT(100));
+    lv_obj_set_style_bg_opa(page, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_scroll_dir(page, LV_DIR_VER);
+    lv_obj_set_scrollbar_mode(page, LV_SCROLLBAR_MODE_OFF);
+    lv_obj_add_flag(page, LV_OBJ_FLAG_CLICKABLE);
+
+    ui_wallpaper_t *wallpaper = ui_wallpaper_attach(page);
+    if (wallpaper != NULL) {
+        lv_obj_add_event_cb(page, ui_page_rooms_delete_cb, LV_EVENT_DELETE, wallpaper);
+    }
+
+    ui_page_create_content(page, "Rooms");
+
+    return page;
+}

--- a/custom/ui/pages/ui_page_rooms.h
+++ b/custom/ui/pages/ui_page_rooms.h
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#pragma once
+
+#ifdef __has_include
+#if __has_include("lvgl.h")
+#ifndef LV_LVGL_H_INCLUDE_SIMPLE
+#define LV_LVGL_H_INCLUDE_SIMPLE
+#endif
+#endif
+#endif
+
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "lvgl/lvgl.h"
+#endif
+
+lv_obj_t *ui_page_rooms_create(lv_obj_t *parent);

--- a/custom/ui/pages/ui_page_weather.c
+++ b/custom/ui/pages/ui_page_weather.c
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include "ui_page_weather.h"
+
+#include "ui_wallpaper.h"
+
+static void ui_page_weather_delete_cb(lv_event_t *event)
+{
+    ui_wallpaper_t *wallpaper = (ui_wallpaper_t *)lv_event_get_user_data(event);
+    ui_wallpaper_detach(wallpaper);
+}
+
+static lv_obj_t *ui_page_create_content(lv_obj_t *page, const char *title_text)
+{
+    lv_obj_t *content = lv_obj_create(page);
+    lv_obj_remove_style_all(content);
+    lv_obj_set_size(content, LV_PCT(100), LV_PCT(100));
+    lv_obj_set_style_bg_opa(content, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_style_pad_left(content, 192, LV_PART_MAIN);
+    lv_obj_set_style_pad_right(content, 48, LV_PART_MAIN);
+    lv_obj_set_style_pad_top(content, 40, LV_PART_MAIN);
+    lv_obj_set_style_pad_bottom(content, 40, LV_PART_MAIN);
+    lv_obj_set_style_pad_row(content, 32, LV_PART_MAIN);
+    lv_obj_set_flex_flow(content, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(content, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+
+    lv_obj_t *title = lv_obj_create(content);
+    lv_obj_remove_style_all(title);
+    lv_obj_set_width(title, LV_PCT(100));
+    lv_obj_set_style_bg_color(title, lv_color_hex(0x132029), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(title, LV_OPA_80, LV_PART_MAIN);
+    lv_obj_set_style_radius(title, 16, LV_PART_MAIN);
+    lv_obj_set_style_shadow_width(title, 24, LV_PART_MAIN);
+    lv_obj_set_style_shadow_opa(title, LV_OPA_50, LV_PART_MAIN);
+    lv_obj_set_style_shadow_ofs_y(title, 10, LV_PART_MAIN);
+    lv_obj_set_style_border_width(title, 0, LV_PART_MAIN);
+    lv_obj_set_style_pad_all(title, 28, LV_PART_MAIN);
+
+    lv_obj_t *label = lv_label_create(title);
+    lv_label_set_text(label, title_text);
+    lv_obj_set_width(label, LV_PCT(100));
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN);
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_32, LV_PART_MAIN);
+    lv_obj_set_style_text_color(label, lv_color_hex(0xf8fafc), LV_PART_MAIN);
+
+    return content;
+}
+
+lv_obj_t *ui_page_weather_create(lv_obj_t *parent)
+{
+    if (parent == NULL) {
+        return NULL;
+    }
+
+    lv_obj_t *page = lv_obj_create(parent);
+    lv_obj_remove_style_all(page);
+    lv_obj_set_size(page, LV_PCT(100), LV_PCT(100));
+    lv_obj_set_style_bg_opa(page, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_scroll_dir(page, LV_DIR_VER);
+    lv_obj_set_scrollbar_mode(page, LV_SCROLLBAR_MODE_OFF);
+    lv_obj_add_flag(page, LV_OBJ_FLAG_CLICKABLE);
+
+    ui_wallpaper_t *wallpaper = ui_wallpaper_attach(page);
+    if (wallpaper != NULL) {
+        lv_obj_add_event_cb(page, ui_page_weather_delete_cb, LV_EVENT_DELETE, wallpaper);
+    }
+
+    ui_page_create_content(page, "Local Climate Station");
+
+    return page;
+}

--- a/custom/ui/pages/ui_page_weather.h
+++ b/custom/ui/pages/ui_page_weather.h
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#pragma once
+
+#ifdef __has_include
+#if __has_include("lvgl.h")
+#ifndef LV_LVGL_H_INCLUDE_SIMPLE
+#define LV_LVGL_H_INCLUDE_SIMPLE
+#endif
+#endif
+#endif
+
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "lvgl/lvgl.h"
+#endif
+
+lv_obj_t *ui_page_weather_create(lv_obj_t *parent);

--- a/custom/ui/ui_nav_rail.c
+++ b/custom/ui/ui_nav_rail.c
@@ -1,0 +1,173 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include "ui_nav_rail.h"
+
+#include <stddef.h>
+
+struct ui_nav_rail_t {
+    lv_obj_t *container;
+    lv_obj_t *buttons[UI_NAV_PAGE_COUNT];
+    ui_nav_page_t active;
+    ui_nav_rail_callback_t callback;
+    void *user_data;
+};
+
+static const char *k_nav_icons[UI_NAV_PAGE_COUNT] = {
+    LV_SYMBOL_DRIVE, LV_SYMBOL_HOME, LV_SYMBOL_VIDEO, LV_SYMBOL_GPS, LV_SYMBOL_AUDIO,
+};
+
+static const char *k_nav_labels[UI_NAV_PAGE_COUNT] = {
+    "ESP32P4", "Rooms", "Frigate Security", "Local Climate", "Media",
+};
+
+static void ui_nav_button_event_cb(lv_event_t *event)
+{
+    ui_nav_rail_t *rail = (ui_nav_rail_t *)lv_event_get_user_data(event);
+    if (rail == NULL || event->code != LV_EVENT_CLICKED) {
+        return;
+    }
+
+    lv_obj_t *target = lv_event_get_target(event);
+    for (uint32_t i = 0; i < UI_NAV_PAGE_COUNT; i++) {
+        if (rail->buttons[i] == target) {
+            if (rail->callback != NULL) {
+                rail->callback(rail, (ui_nav_page_t)i, rail->user_data);
+            }
+            break;
+        }
+    }
+}
+
+static void ui_nav_apply_button_style(lv_obj_t *button)
+{
+    lv_obj_set_width(button, LV_PCT(100));
+    lv_obj_set_style_radius(button, 16, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(button, lv_color_hex(0x1b2430), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(button, LV_OPA_90, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(button, lv_color_hex(0x2563eb), LV_PART_MAIN | LV_STATE_CHECKED);
+    lv_obj_set_style_bg_opa(button, LV_OPA_95, LV_PART_MAIN | LV_STATE_CHECKED);
+    lv_obj_set_style_shadow_width(button, 18, LV_PART_MAIN | LV_STATE_CHECKED);
+    lv_obj_set_style_shadow_opa(button, LV_OPA_60, LV_PART_MAIN | LV_STATE_CHECKED);
+    lv_obj_set_style_shadow_ofs_y(button, 6, LV_PART_MAIN | LV_STATE_CHECKED);
+    lv_obj_set_style_border_width(button, 0, LV_PART_MAIN);
+    lv_obj_set_style_outline_width(button, 2, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+    lv_obj_set_style_outline_color(button, lv_color_hex(0x38bdf8), LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+    lv_obj_set_style_outline_pad(button, 4, LV_PART_MAIN | LV_STATE_FOCUS_KEY);
+    lv_obj_set_style_text_color(button, lv_color_hex(0xe6edf3), LV_PART_MAIN);
+    lv_obj_set_style_text_color(button, lv_color_hex(0xf8fafc), LV_PART_MAIN | LV_STATE_CHECKED);
+    lv_obj_set_style_pad_all(button, 12, LV_PART_MAIN);
+    lv_obj_set_style_pad_gap(button, 6, LV_PART_MAIN);
+    lv_obj_set_flex_flow(button, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(button, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+}
+
+static void ui_nav_add_button_content(lv_obj_t *button, uint32_t index)
+{
+    lv_obj_t *icon = lv_label_create(button);
+    lv_label_set_text(icon, k_nav_icons[index]);
+    lv_obj_set_style_text_font(icon, &lv_font_montserrat_32, LV_PART_MAIN);
+    lv_obj_set_style_text_color(icon, lv_color_hex(0xe6edf3), LV_PART_MAIN);
+
+    lv_obj_t *label = lv_label_create(button);
+    lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
+    lv_obj_set_width(label, LV_PCT(100));
+    lv_label_set_text(label, k_nav_labels[index]);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_16, LV_PART_MAIN);
+    lv_obj_set_style_text_color(label, lv_color_hex(0xcad3df), LV_PART_MAIN);
+}
+
+ui_nav_rail_t *ui_nav_rail_create(lv_obj_t *parent, ui_nav_rail_callback_t callback, void *user_data)
+{
+    if (parent == NULL) {
+        return NULL;
+    }
+
+    ui_nav_rail_t *rail = (ui_nav_rail_t *)lv_malloc(sizeof(ui_nav_rail_t));
+    if (rail == NULL) {
+        return NULL;
+    }
+    lv_memset_00(rail, sizeof(ui_nav_rail_t));
+
+    rail->container = lv_obj_create(parent);
+    lv_obj_set_size(rail->container, 156, LV_PCT(100));
+    lv_obj_align(rail->container, LV_ALIGN_LEFT_MID, 24, 0);
+    lv_obj_remove_flag(rail->container, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_style_radius(rail->container, 20, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(rail->container, lv_color_hex(0x11161d), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(rail->container, LV_OPA_90, LV_PART_MAIN);
+    lv_obj_set_style_shadow_width(rail->container, 28, LV_PART_MAIN);
+    lv_obj_set_style_shadow_opa(rail->container, LV_OPA_45, LV_PART_MAIN);
+    lv_obj_set_style_shadow_ofs_x(rail->container, 0, LV_PART_MAIN);
+    lv_obj_set_style_shadow_ofs_y(rail->container, 10, LV_PART_MAIN);
+    lv_obj_set_style_border_width(rail->container, 0, LV_PART_MAIN);
+    lv_obj_set_style_pad_all(rail->container, 18, LV_PART_MAIN);
+    lv_obj_set_style_pad_row(rail->container, 18, LV_PART_MAIN);
+    lv_obj_set_style_pad_top(rail->container, 32, LV_PART_MAIN);
+    lv_obj_set_style_pad_bottom(rail->container, 32, LV_PART_MAIN);
+    lv_obj_set_style_pad_gap(rail->container, 16, LV_PART_MAIN);
+    lv_obj_set_flex_flow(rail->container, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(rail->container, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+    rail->callback  = callback;
+    rail->user_data = user_data;
+
+    for (uint32_t i = 0; i < UI_NAV_PAGE_COUNT; i++) {
+        lv_obj_t *button = lv_button_create(rail->container);
+        lv_obj_add_flag(button, LV_OBJ_FLAG_CHECKABLE);
+        lv_obj_add_event_cb(button, ui_nav_button_event_cb, LV_EVENT_CLICKED, rail);
+        ui_nav_apply_button_style(button);
+        ui_nav_add_button_content(button, i);
+        rail->buttons[i] = button;
+    }
+
+    ui_nav_rail_set_active(rail, UI_NAV_PAGE_DEFAULT);
+
+    return rail;
+}
+
+void ui_nav_rail_destroy(ui_nav_rail_t *rail)
+{
+    if (rail == NULL) {
+        return;
+    }
+
+    if (rail->container != NULL) {
+        lv_obj_del(rail->container);
+        rail->container = NULL;
+    }
+
+    lv_free(rail);
+}
+
+void ui_nav_rail_set_active(ui_nav_rail_t *rail, ui_nav_page_t page)
+{
+    if (rail == NULL || page >= UI_NAV_PAGE_COUNT) {
+        return;
+    }
+
+    rail->active = page;
+    for (uint32_t i = 0; i < UI_NAV_PAGE_COUNT; i++) {
+        lv_obj_t *button = rail->buttons[i];
+        if (button == NULL) {
+            continue;
+        }
+
+        if (i == (uint32_t)page) {
+            lv_obj_add_state(button, LV_STATE_CHECKED);
+        } else {
+            lv_obj_clear_state(button, LV_STATE_CHECKED);
+        }
+    }
+}
+
+lv_obj_t *ui_nav_rail_get_container(ui_nav_rail_t *rail)
+{
+    if (rail == NULL) {
+        return NULL;
+    }
+    return rail->container;
+}

--- a/custom/ui/ui_nav_rail.h
+++ b/custom/ui/ui_nav_rail.h
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#pragma once
+
+#ifdef __has_include
+#if __has_include("lvgl.h")
+#ifndef LV_LVGL_H_INCLUDE_SIMPLE
+#define LV_LVGL_H_INCLUDE_SIMPLE
+#endif
+#endif
+#endif
+
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "lvgl/lvgl.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    UI_NAV_PAGE_DEFAULT = 0,
+    UI_NAV_PAGE_ROOMS,
+    UI_NAV_PAGE_CCTV,
+    UI_NAV_PAGE_WEATHER,
+    UI_NAV_PAGE_MEDIA,
+    UI_NAV_PAGE_COUNT
+} ui_nav_page_t;
+
+typedef struct ui_nav_rail_t ui_nav_rail_t;
+
+typedef void (*ui_nav_rail_callback_t)(ui_nav_rail_t *rail, ui_nav_page_t page, void *user_data);
+
+ui_nav_rail_t *ui_nav_rail_create(lv_obj_t *parent, ui_nav_rail_callback_t callback, void *user_data);
+void ui_nav_rail_destroy(ui_nav_rail_t *rail);
+void ui_nav_rail_set_active(ui_nav_rail_t *rail, ui_nav_page_t page);
+lv_obj_t *ui_nav_rail_get_container(ui_nav_rail_t *rail);
+
+#ifdef __cplusplus
+}
+#endif

--- a/custom/ui/ui_root.c
+++ b/custom/ui/ui_root.c
@@ -1,0 +1,142 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include "ui_root.h"
+
+#include "pages/ui_page_cctv.h"
+#include "pages/ui_page_media.h"
+#include "pages/ui_page_rooms.h"
+#include "pages/ui_page_weather.h"
+
+struct ui_root_t {
+    lv_obj_t *screen;
+    ui_nav_rail_t *nav;
+    lv_obj_t *pages[UI_NAV_PAGE_COUNT];
+    ui_nav_page_t active;
+};
+
+static void ui_root_nav_changed(ui_nav_rail_t *rail, ui_nav_page_t page, void *user_data)
+{
+    LV_UNUSED(rail);
+    ui_root_t *root = (ui_root_t *)user_data;
+    if (root == NULL) {
+        return;
+    }
+
+    ui_root_show_page(root, page);
+}
+
+static void ui_root_hide_all_overlays(ui_root_t *root)
+{
+    for (uint32_t i = 0; i < UI_NAV_PAGE_COUNT; i++) {
+        if (i == UI_NAV_PAGE_DEFAULT) {
+            continue;
+        }
+        if (root->pages[i] != NULL) {
+            lv_obj_add_flag(root->pages[i], LV_OBJ_FLAG_HIDDEN);
+        }
+    }
+}
+
+static void ui_root_create_pages(ui_root_t *root)
+{
+    root->pages[UI_NAV_PAGE_ROOMS]   = ui_page_rooms_create(root->screen);
+    root->pages[UI_NAV_PAGE_CCTV]    = ui_page_cctv_create(root->screen);
+    root->pages[UI_NAV_PAGE_WEATHER] = ui_page_weather_create(root->screen);
+    root->pages[UI_NAV_PAGE_MEDIA]   = ui_page_media_create(root->screen);
+
+    for (uint32_t i = 0; i < UI_NAV_PAGE_COUNT; i++) {
+        if (root->pages[i] == NULL) {
+            continue;
+        }
+        lv_obj_move_foreground(root->pages[i]);
+        lv_obj_add_flag(root->pages[i], LV_OBJ_FLAG_HIDDEN);
+    }
+}
+
+ui_root_t *ui_root_create(void)
+{
+    ui_root_t *root = (ui_root_t *)lv_malloc(sizeof(ui_root_t));
+    if (root == NULL) {
+        return NULL;
+    }
+    lv_memset_00(root, sizeof(ui_root_t));
+
+    root->screen = lv_screen_active();
+
+    root->nav = ui_nav_rail_create(root->screen, ui_root_nav_changed, root);
+    if (root->nav == NULL) {
+        lv_free(root);
+        return NULL;
+    }
+
+    ui_root_create_pages(root);
+
+    lv_obj_move_foreground(ui_nav_rail_get_container(root->nav));
+    ui_root_hide_all_overlays(root);
+    root->active = UI_NAV_PAGE_DEFAULT;
+
+    return root;
+}
+
+void ui_root_destroy(ui_root_t *root)
+{
+    if (root == NULL) {
+        return;
+    }
+
+    for (uint32_t i = 0; i < UI_NAV_PAGE_COUNT; i++) {
+        if (root->pages[i] != NULL) {
+            lv_obj_del(root->pages[i]);
+            root->pages[i] = NULL;
+        }
+    }
+
+    if (root->nav != NULL) {
+        ui_nav_rail_destroy(root->nav);
+        root->nav = NULL;
+    }
+
+    lv_free(root);
+}
+
+void ui_root_show_page(ui_root_t *root, ui_nav_page_t page)
+{
+    if (root == NULL || page >= UI_NAV_PAGE_COUNT) {
+        return;
+    }
+
+    if (page == UI_NAV_PAGE_DEFAULT) {
+        ui_root_hide_all_overlays(root);
+    } else {
+        for (uint32_t i = 0; i < UI_NAV_PAGE_COUNT; i++) {
+            if (i == UI_NAV_PAGE_DEFAULT) {
+                continue;
+            }
+            lv_obj_t *candidate = root->pages[i];
+            if (candidate == NULL) {
+                continue;
+            }
+            if (i == (uint32_t)page) {
+                lv_obj_clear_flag(candidate, LV_OBJ_FLAG_HIDDEN);
+                lv_obj_move_foreground(candidate);
+            } else {
+                lv_obj_add_flag(candidate, LV_OBJ_FLAG_HIDDEN);
+            }
+        }
+    }
+
+    lv_obj_move_foreground(ui_nav_rail_get_container(root->nav));
+    ui_nav_rail_set_active(root->nav, page);
+    root->active = page;
+}
+
+ui_nav_page_t ui_root_get_active(const ui_root_t *root)
+{
+    if (root == NULL) {
+        return UI_NAV_PAGE_DEFAULT;
+    }
+    return root->active;
+}

--- a/custom/ui/ui_root.h
+++ b/custom/ui/ui_root.h
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#pragma once
+
+#include "ui_nav_rail.h"
+
+#ifdef __has_include
+#if __has_include("lvgl.h")
+#ifndef LV_LVGL_H_INCLUDE_SIMPLE
+#define LV_LVGL_H_INCLUDE_SIMPLE
+#endif
+#endif
+#endif
+
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "lvgl/lvgl.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ui_root_t ui_root_t;
+
+ui_root_t *ui_root_create(void);
+void ui_root_destroy(ui_root_t *root);
+void ui_root_show_page(ui_root_t *root, ui_nav_page_t page);
+ui_nav_page_t ui_root_get_active(const ui_root_t *root);
+
+#ifdef __cplusplus
+}
+#endif

--- a/custom/ui/ui_wallpaper.c
+++ b/custom/ui/ui_wallpaper.c
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include "ui_wallpaper.h"
+
+#include "custom/assets/bg/bg_images.h"
+
+#define WALLPAPER_SWITCH_PERIOD_MS 30000
+
+static const lv_image_dsc_t *k_wallpapers[] = {
+    &bg_wallpaper_1,
+    &bg_wallpaper_2,
+};
+
+static void ui_wallpaper_timer_cb(lv_timer_t *timer)
+{
+    ui_wallpaper_t *wallpaper = (ui_wallpaper_t *)timer->user_data;
+    if (wallpaper == NULL || wallpaper->img == NULL) {
+        return;
+    }
+
+    wallpaper->idx ^= 1U;
+    lv_image_set_src(wallpaper->img, k_wallpapers[wallpaper->idx]);
+}
+
+ui_wallpaper_t *ui_wallpaper_attach(lv_obj_t *parent)
+{
+    if (parent == NULL) {
+        return NULL;
+    }
+
+    ui_wallpaper_t *wallpaper = (ui_wallpaper_t *)lv_malloc(sizeof(ui_wallpaper_t));
+    if (wallpaper == NULL) {
+        return NULL;
+    }
+    lv_memset_00(wallpaper, sizeof(ui_wallpaper_t));
+
+    wallpaper->img = lv_image_create(parent);
+    lv_obj_add_flag(wallpaper->img, LV_OBJ_FLAG_IGNORE_LAYOUT);
+    lv_obj_set_size(wallpaper->img, LV_PCT(100), LV_PCT(100));
+    lv_obj_center(wallpaper->img);
+    lv_image_set_src(wallpaper->img, k_wallpapers[0]);
+    lv_obj_set_style_bg_opa(wallpaper->img, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_style_border_width(wallpaper->img, 0, LV_PART_MAIN);
+    lv_obj_move_background(wallpaper->img);
+
+    wallpaper->timer = lv_timer_create(ui_wallpaper_timer_cb, WALLPAPER_SWITCH_PERIOD_MS, wallpaper);
+    if (wallpaper->timer == NULL) {
+        ui_wallpaper_detach(wallpaper);
+        return NULL;
+    }
+
+    return wallpaper;
+}
+
+void ui_wallpaper_detach(ui_wallpaper_t *wallpaper)
+{
+    if (wallpaper == NULL) {
+        return;
+    }
+
+    if (wallpaper->timer != NULL) {
+        lv_timer_del(wallpaper->timer);
+        wallpaper->timer = NULL;
+    }
+
+    if (wallpaper->img != NULL) {
+        lv_obj_del(wallpaper->img);
+        wallpaper->img = NULL;
+    }
+
+    lv_free(wallpaper);
+}

--- a/custom/ui/ui_wallpaper.h
+++ b/custom/ui/ui_wallpaper.h
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#pragma once
+
+#ifdef __has_include
+#if __has_include("lvgl.h")
+#ifndef LV_LVGL_H_INCLUDE_SIMPLE
+#define LV_LVGL_H_INCLUDE_SIMPLE
+#endif
+#endif
+#endif
+
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "lvgl/lvgl.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ui_wallpaper_t {
+    lv_obj_t *img;
+    uint8_t idx;
+    lv_timer_t *timer;
+} ui_wallpaper_t;
+
+ui_wallpaper_t *ui_wallpaper_attach(lv_obj_t *parent);
+void ui_wallpaper_detach(ui_wallpaper_t *wallpaper);
+
+#ifdef __cplusplus
+}
+#endif

--- a/docs/wireframes.md
+++ b/docs/wireframes.md
@@ -19,7 +19,8 @@ Primary integration: **Home Assistant (MQTT + Assist)**, **Frigate**.
 
 ## Global Structure (Navigation)
 - Tabs: **Home**, **Rooms**, **Security**, **Climate** (optional **Media**)
-- Right-edge **tab rail** (landscape) with icon+label
+- Left-side **nav rail** (implemented) with icon+label buttons for ESP32P4 demo, Rooms, Frigate Security, Local Climate Station, and TV Controls
+- Full-bleed wallpaper rotates between `custom/assets/bg/1.png` and `custom/assets/bg/2.png` every 30 seconds on custom pages
 - **Control Center** opens as modal sheet (swipe down from header or tap status icons)
 
 ```mermaid

--- a/platforms/desktop/CMakeLists.txt
+++ b/platforms/desktop/CMakeLists.txt
@@ -23,9 +23,13 @@ file(GLOB_RECURSE APP_LAYER_SRCS
     app/*.c
     app/*.cc
     app/*.cpp
+    custom/*.c
+    custom/*.cc
+    custom/*.cpp
 )
 set(APP_LAYER_INCS
     app/
+    custom/
 )
 
 # Lvgl
@@ -43,9 +47,13 @@ file(GLOB_RECURSE APP_LAYER_SRCS
     app/*.c
     app/*.cc
     app/*.cpp
+    custom/*.c
+    custom/*.cc
+    custom/*.cpp
 )
 set(APP_LAYER_INCS
     app/
+    custom/
 )
 
 # 桌面端源文件

--- a/platforms/tab5/main/CMakeLists.txt
+++ b/platforms/tab5/main/CMakeLists.txt
@@ -2,10 +2,14 @@ file(GLOB_RECURSE APP_LAYER_SRCS
     ../../../app/*.c
     ../../../app/*.cc
     ../../../app/*.cpp
+    ../../../custom/*.c
+    ../../../custom/*.cc
+    ../../../custom/*.cpp
 )
 
 set(APP_LAYER_INCS
     ../../../app
+    ../../../custom
 )
 
 file(GLOB_RECURSE MY_HAL_SRCS


### PR DESCRIPTION
## Summary
- add reusable wallpaper helper and embed rotating background assets
- introduce left navigation rail with icon buttons and integrate it into the launcher view
- scaffold Rooms, Frigate Security, Local Climate Station, and TV Controls pages with styled headers and documentation updates
- include custom sources in both ESP-IDF and desktop builds so the new UI modules compile

## Testing
- `idf.py build` *(fails: idf.py not available in container)*
- `npx markdownlint-cli docs` *(fails: repository contains pre-existing lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68caa4cdb4d08324afc3adf81fa881ef