### PR TITLE
feat(assets): load wallpapers from filesystem (PNG via LVGL), SD fallback

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,4 +4,3 @@
 *.otf filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text
-custom/assets/** filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 build
 dependencies
 .DS_Store
+
+# Generated LVGL image blobs (runtime PNGs load from filesystem)
+custom/assets/bg/*.c
+custom/assets/bg/*.h

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Our custom data is in the following folders:
 
 > See [`docs/wireframes.md`](docs/wireframes.md) for the low-fi design spec and [`docs/AI_Codex_Guide.md`](docs/AI_Codex_Guide.md) for AI coding guidelines.
 
+## 🖼️ Assets at Runtime
+
+- Wallpapers are regular PNG files stored in flash at `/custom/assets/bg/1.png` and `/custom/assets/bg/2.png`.
+- If an SD card is present, matching files at `/sdcard/custom/assets/bg/1.png` and `/sdcard/custom/assets/bg/2.png` override the built-in images.
+- LVGL mounts the POSIX filesystem on drive letter `A`, so runtime image sources look like `A:/custom/assets/bg/1.png`.
+
 ## 🔧 Prerequisites
 
 - **ESP-IDF 5.x** (P4 target support required)

--- a/custom/assets/asset_mount.c
+++ b/custom/assets/asset_mount.c
@@ -1,0 +1,264 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include "custom/assets/asset_mount.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+#ifdef __has_include
+#if __has_include("lvgl.h")
+#ifndef LV_LVGL_H_INCLUDE_SIMPLE
+#define LV_LVGL_H_INCLUDE_SIMPLE
+#endif
+#endif
+#endif
+
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
+#else
+#include "lvgl/lvgl.h"
+#endif
+
+#if LV_USE_FS_IF
+
+static lv_fs_res_t posix_close(lv_fs_drv_t *drv, void *file_p);
+static lv_fs_res_t posix_read(lv_fs_drv_t *drv, void *file_p, void *buf, uint32_t btr, uint32_t *br);
+static lv_fs_res_t posix_write(lv_fs_drv_t *drv, void *file_p, const void *buf, uint32_t btw, uint32_t *bw);
+static lv_fs_res_t posix_seek(lv_fs_drv_t *drv, void *file_p, uint32_t pos, lv_fs_whence_t whence);
+static lv_fs_res_t posix_tell(lv_fs_drv_t *drv, void *file_p, uint32_t *pos_p);
+
+static lv_fs_res_t posix_close(lv_fs_drv_t *drv, void *file_p)
+{
+    LV_UNUSED(drv);
+    if (file_p == NULL) {
+        return LV_FS_RES_INV_PARAM;
+    }
+    FILE *f = (FILE *)file_p;
+    return fclose(f) == 0 ? LV_FS_RES_OK : LV_FS_RES_FS_ERR;
+}
+
+static lv_fs_res_t posix_read(lv_fs_drv_t *drv, void *file_p, void *buf, uint32_t btr, uint32_t *br)
+{
+    LV_UNUSED(drv);
+    if (file_p == NULL || buf == NULL) {
+        return LV_FS_RES_INV_PARAM;
+    }
+    FILE *f   = (FILE *)file_p;
+    size_t rd = fread(buf, 1, btr, f);
+    if (br != NULL) {
+        *br = (uint32_t)rd;
+    }
+    if (rd < btr && ferror(f)) {
+        clearerr(f);
+        return LV_FS_RES_FS_ERR;
+    }
+    return LV_FS_RES_OK;
+}
+
+static lv_fs_res_t posix_write(lv_fs_drv_t *drv, void *file_p, const void *buf, uint32_t btw, uint32_t *bw)
+{
+    LV_UNUSED(drv);
+    if (file_p == NULL || buf == NULL) {
+        return LV_FS_RES_INV_PARAM;
+    }
+    FILE *f   = (FILE *)file_p;
+    size_t wr = fwrite(buf, 1, btw, f);
+    if (bw != NULL) {
+        *bw = (uint32_t)wr;
+    }
+    if (wr < btw) {
+        return LV_FS_RES_FS_ERR;
+    }
+    return LV_FS_RES_OK;
+}
+
+static lv_fs_res_t posix_seek(lv_fs_drv_t *drv, void *file_p, uint32_t pos, lv_fs_whence_t whence)
+{
+    LV_UNUSED(drv);
+    if (file_p == NULL) {
+        return LV_FS_RES_INV_PARAM;
+    }
+    FILE *f = (FILE *)file_p;
+
+    int origin = SEEK_SET;
+    switch (whence) {
+        case LV_FS_SEEK_CUR:
+            origin = SEEK_CUR;
+            break;
+        case LV_FS_SEEK_END:
+            origin = SEEK_END;
+            break;
+        case LV_FS_SEEK_SET:
+        default:
+            origin = SEEK_SET;
+            break;
+    }
+
+    return fseek(f, (long)pos, origin) == 0 ? LV_FS_RES_OK : LV_FS_RES_FS_ERR;
+}
+
+static lv_fs_res_t posix_tell(lv_fs_drv_t *drv, void *file_p, uint32_t *pos_p)
+{
+    LV_UNUSED(drv);
+    if (file_p == NULL || pos_p == NULL) {
+        return LV_FS_RES_INV_PARAM;
+    }
+    FILE *f  = (FILE *)file_p;
+    long pos = ftell(f);
+    if (pos < 0) {
+        return LV_FS_RES_FS_ERR;
+    }
+    *pos_p = (uint32_t)pos;
+    return LV_FS_RES_OK;
+}
+
+static void *posix_open(lv_fs_drv_t *drv, const char *path, lv_fs_mode_t mode)
+{
+    LV_UNUSED(drv);
+    const char *flags = NULL;
+    bool rd           = (mode & LV_FS_MODE_RD) != 0U;
+    bool wr           = (mode & LV_FS_MODE_WR) != 0U;
+
+    if (rd && wr) {
+        flags = "rb+";
+    } else if (wr) {
+        flags = "wb";
+    } else {
+        flags = "rb";
+    }
+
+    return fopen(path, flags);
+}
+
+static void lv_fs_if_init(void)
+{
+#if defined(LV_FS_IF_POSIX) && (LV_FS_IF_POSIX != '\0')
+    static bool registered = false;
+    static lv_fs_drv_t drv;
+    if (registered) {
+        return;
+    }
+
+    lv_fs_drv_init(&drv);
+    drv.letter   = LV_FS_IF_POSIX;
+    drv.open_cb  = posix_open;
+    drv.close_cb = posix_close;
+    drv.read_cb  = posix_read;
+    drv.write_cb = posix_write;
+    drv.seek_cb  = posix_seek;
+    drv.tell_cb  = posix_tell;
+
+    lv_fs_drv_register(&drv);
+    registered = true;
+#endif
+}
+#endif
+
+#if defined(ESP_PLATFORM)
+#include "driver/sdmmc_host.h"
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp_vfs_fat.h"
+#include "sdmmc_cmd.h"
+#endif
+
+#if defined(ESP_PLATFORM)
+#define ASSET_LOGI(tag, fmt, ...) ESP_LOGI(tag, fmt, ##__VA_ARGS__)
+#define ASSET_LOGW(tag, fmt, ...) ESP_LOGW(tag, fmt, ##__VA_ARGS__)
+#else
+#define ASSET_LOGI(tag, fmt, ...) LV_LOG_INFO(fmt, ##__VA_ARGS__)
+#define ASSET_LOGW(tag, fmt, ...) LV_LOG_WARN(fmt, ##__VA_ARGS__)
+#endif
+
+#define SD_MOUNT_POINT      "/sdcard"
+#define INTERNAL_ASSET_ROOT "/custom/assets"
+#define BG_RELATIVE         "/bg"
+#define FALLBACK_1          INTERNAL_ASSET_ROOT BG_RELATIVE "/1.png"
+#define FALLBACK_2          INTERNAL_ASSET_ROOT BG_RELATIVE "/2.png"
+
+static const char *k_tag = "assets";
+
+static bool s_fs_initialized = false;
+static bool s_sd_ok          = false;
+static bool s_warned_missing = false;
+
+static bool path_exists(const char *path)
+{
+    if (path == NULL) {
+        return false;
+    }
+    struct stat st;
+    return stat(path, &st) == 0;
+}
+
+static const char *pick_file(const char *relative, const char *fallback)
+{
+    static char path_buffer[128];
+
+    if (s_sd_ok) {
+        int written = snprintf(path_buffer, sizeof(path_buffer), "%s%s/%s", SD_MOUNT_POINT, BG_RELATIVE, relative);
+        if (written > 0 && written < (int)sizeof(path_buffer) && path_exists(path_buffer)) {
+            return path_buffer;
+        }
+    }
+
+    int written = snprintf(path_buffer, sizeof(path_buffer), "%s%s/%s", INTERNAL_ASSET_ROOT, BG_RELATIVE, relative);
+    if (written > 0 && written < (int)sizeof(path_buffer) && path_exists(path_buffer)) {
+        return path_buffer;
+    }
+
+    if (!s_warned_missing) {
+        s_warned_missing = true;
+        ASSET_LOGW(k_tag, "Falling back to built-in wallpaper path: %s", fallback);
+    }
+    return fallback;
+}
+
+void assets_fs_init(void)
+{
+    if (s_fs_initialized) {
+        return;
+    }
+    s_fs_initialized = true;
+
+#if LV_USE_FS_IF
+    lv_fs_if_init();
+#else
+    LV_LOG_WARN("LV_USE_FS_IF disabled; wallpaper loading from FS unavailable");
+#endif
+
+#if defined(ESP_PLATFORM)
+    sdmmc_host_t host                        = SDMMC_HOST_DEFAULT();
+    sdmmc_slot_config_t slot_config          = SDMMC_SLOT_CONFIG_DEFAULT();
+    esp_vfs_fat_sdmmc_mount_config_t mnt_cfg = {
+        .format_if_mount_failed = false,
+        .max_files              = 4,
+        .allocation_unit_size   = 16 * 1024,
+    };
+    sdmmc_card_t *card = NULL;
+    esp_err_t err      = esp_vfs_fat_sdmmc_mount(SD_MOUNT_POINT, &host, &slot_config, &mnt_cfg, &card);
+    if (err == ESP_OK) {
+        s_sd_ok = true;
+        ASSET_LOGI(k_tag, "SD mounted at %s", SD_MOUNT_POINT);
+    } else {
+        ASSET_LOGW(k_tag, "SD not mounted (err=0x%x). Proceeding without SD.", (unsigned int)err);
+    }
+#else
+    ASSET_LOGI(k_tag, "Desktop build: using host filesystem without SD mount");
+#endif
+}
+
+const char *assets_path_1(void)
+{
+    return pick_file("1.png", FALLBACK_1);
+}
+
+const char *assets_path_2(void)
+{
+    return pick_file("2.png", FALLBACK_2);
+}

--- a/custom/assets/asset_mount.h
+++ b/custom/assets/asset_mount.h
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void assets_fs_init(void);
+const char *assets_path_1(void);
+const char *assets_path_2(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/custom/assets/bg/bg_images.c
+++ b/custom/assets/bg/bg_images.c
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d02d14fb0cad699baef1c034eb847a1911665aace8174b88f1de27e9eeba42a7
-size 22666838

--- a/custom/assets/bg/bg_images.h
+++ b/custom/assets/bg/bg_images.h
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4f3dd79971bd7a141f2b4df7b8bcb10b403dc0943513c1f4b486da3b3d7fd8e8
-size 454

--- a/custom/ui/ui_wallpaper.c
+++ b/custom/ui/ui_wallpaper.c
@@ -3,16 +3,30 @@
  *
  * SPDX-License-Identifier: MIT
  */
+#include <stdio.h>
+
 #include "ui_wallpaper.h"
 
-#include "custom/assets/bg/bg_images.h"
+#include "custom/assets/asset_mount.h"
 
 #define WALLPAPER_SWITCH_PERIOD_MS 30000
 
-static const lv_image_dsc_t *k_wallpapers[] = {
-    &bg_wallpaper_1,
-    &bg_wallpaper_2,
-};
+static void ui_wallpaper_set_src(const ui_wallpaper_t *wallpaper, bool second)
+{
+    if (wallpaper == NULL || wallpaper->img == NULL) {
+        return;
+    }
+
+    const char *path = second ? assets_path_2() : assets_path_1();
+    static char lv_path[256];
+    int written = snprintf(lv_path, sizeof(lv_path), "A:%s", path);
+    if (written < 0 || written >= (int)sizeof(lv_path)) {
+        LV_LOG_WARN("Wallpaper path truncated: %s", path);
+        return;
+    }
+
+    lv_image_set_src(wallpaper->img, lv_path);
+}
 
 static void ui_wallpaper_timer_cb(lv_timer_t *timer)
 {
@@ -22,7 +36,7 @@ static void ui_wallpaper_timer_cb(lv_timer_t *timer)
     }
 
     wallpaper->idx ^= 1U;
-    lv_image_set_src(wallpaper->img, k_wallpapers[wallpaper->idx]);
+    ui_wallpaper_set_src(wallpaper, wallpaper->idx != 0U);
 }
 
 ui_wallpaper_t *ui_wallpaper_attach(lv_obj_t *parent)
@@ -37,11 +51,13 @@ ui_wallpaper_t *ui_wallpaper_attach(lv_obj_t *parent)
     }
     lv_memset_00(wallpaper, sizeof(ui_wallpaper_t));
 
+    assets_fs_init();
+
     wallpaper->img = lv_image_create(parent);
     lv_obj_add_flag(wallpaper->img, LV_OBJ_FLAG_IGNORE_LAYOUT);
     lv_obj_set_size(wallpaper->img, LV_PCT(100), LV_PCT(100));
     lv_obj_center(wallpaper->img);
-    lv_image_set_src(wallpaper->img, k_wallpapers[0]);
+    ui_wallpaper_set_src(wallpaper, false);
     lv_obj_set_style_bg_opa(wallpaper->img, LV_OPA_TRANSP, LV_PART_MAIN);
     lv_obj_set_style_border_width(wallpaper->img, 0, LV_PART_MAIN);
     lv_obj_move_background(wallpaper->img);

--- a/lv_conf.h
+++ b/lv_conf.h
@@ -757,11 +757,19 @@
     #define LV_FS_ARDUINO_SD_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
 #endif
 
+/*Bridge to common file systems (POSIX, FatFS, etc.)*/
+#define LV_USE_FS_IF 1
+#if LV_USE_FS_IF
+    #define LV_FS_IF_POSIX 'A'
+    #define LV_FS_IF_FATFS '\0'
+    #define LV_FS_IF_PC '\0'
+#endif
+
 /*LODEPNG decoder library*/
 #define LV_USE_LODEPNG 0
 
 /*PNG decoder(libpng) library*/
-#define LV_USE_LIBPNG 0
+#define LV_USE_LIBPNG 1
 
 /*BMP decoder library*/
 #define LV_USE_BMP 0


### PR DESCRIPTION
## Summary
- add an assets filesystem helper that registers a POSIX LVGL driver, mounts the SD card, and picks wallpaper PNG paths with flash fallback
- enable LVGL's libpng decoder and filesystem bridge, and update the wallpaper widget to source runtime files instead of compiled blobs
- drop generated background assets, update ignore rules, and document the new runtime wallpaper workflow

## Testing
- `idf.py build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cab355cbe08324a1774713aa47a406