### PR TITLE
fix: include ui_root header from component include path

### DIFF
--- a/app/apps/app_launcher/view/view.cpp
+++ b/app/apps/app_launcher/view/view.cpp
@@ -11,7 +11,7 @@
 #include <smooth_ui_toolkit.h>
 #include <smooth_lvgl.h>
 #include <apps/utils/audio/audio.h>
-#include "custom/ui/ui_root.h"
+#include "ui/ui_root.h"
 
 using namespace launcher_view;
 using namespace smooth_ui_toolkit;


### PR DESCRIPTION
## Summary
- fix the launcher view include so it resolves the ui_root header via the component include directory

## Testing
- ⚠️ `idf.py set-target esp32p4` *(fails: idf.py not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cad55a681c8324a5c2b5993625c69a