### PR TITLE
fix(ui): include wallpaper headers

### DIFF
--- a/custom/ui/pages/ui_page_cctv.c
+++ b/custom/ui/pages/ui_page_cctv.c
@@ -5,7 +5,7 @@
  */
 #include "ui_page_cctv.h"
 
-#include "ui_wallpaper.h"
+#include "../ui_wallpaper.h"
 
 static void ui_page_cctv_delete_cb(lv_event_t *event)
 {

--- a/custom/ui/pages/ui_page_media.c
+++ b/custom/ui/pages/ui_page_media.c
@@ -5,7 +5,7 @@
  */
 #include "ui_page_media.h"
 
-#include "ui_wallpaper.h"
+#include "../ui_wallpaper.h"
 
 static void ui_page_media_delete_cb(lv_event_t *event)
 {

--- a/custom/ui/pages/ui_page_rooms.c
+++ b/custom/ui/pages/ui_page_rooms.c
@@ -5,7 +5,7 @@
  */
 #include "ui_page_rooms.h"
 
-#include "ui_wallpaper.h"
+#include "../ui_wallpaper.h"
 
 static void ui_page_rooms_delete_cb(lv_event_t *event)
 {

--- a/custom/ui/pages/ui_page_weather.c
+++ b/custom/ui/pages/ui_page_weather.c
@@ -5,7 +5,7 @@
  */
 #include "ui_page_weather.h"
 
-#include "ui_wallpaper.h"
+#include "../ui_wallpaper.h"
 
 static void ui_page_weather_delete_cb(lv_event_t *event)
 {


### PR DESCRIPTION
## Summary
- update the Tab5 overlay pages to include `ui_wallpaper.h` via a relative path so the header resolves during the build

## Testing
- not run (idf.py unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68cadc5f576883248785eac76cd7e45b