### PR TITLE
Fix asset include paths for custom components

### DIFF
--- a/custom/assets/asset_mount.c
+++ b/custom/assets/asset_mount.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-#include "custom/assets/asset_mount.h"
+#include "assets/asset_mount.h"
 
 #include <stdbool.h>
 #include <stddef.h>

--- a/custom/ui/ui_wallpaper.c
+++ b/custom/ui/ui_wallpaper.c
@@ -7,7 +7,7 @@
 
 #include "ui_wallpaper.h"
 
-#include "custom/assets/asset_mount.h"
+#include "assets/asset_mount.h"
 
 #define WALLPAPER_SWITCH_PERIOD_MS 30000
 


### PR DESCRIPTION
## Summary
- include the asset mount header via the custom include directory instead of hardcoding the project root
- update the wallpaper view to use the same relative asset header path so the build can resolve it

## Testing
- clang-format -style=file -i custom/assets/asset_mount.c custom/ui/ui_wallpaper.c
- idf.py -C platforms/tab5 build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68caecff15048324b6620e163689ea71