### PR TITLE
fix: align tab5 ui with lvgl 9 api

### DIFF
--- a/custom/ui/pages/ui_page_cctv.c
+++ b/custom/ui/pages/ui_page_cctv.c
@@ -31,7 +31,7 @@ static lv_obj_t *ui_page_create_content(lv_obj_t *page, const char *title_text)
     lv_obj_remove_style_all(title);
     lv_obj_set_width(title, LV_PCT(100));
     lv_obj_set_style_bg_color(title, lv_color_hex(0x141e28), LV_PART_MAIN);
-    lv_obj_set_style_bg_opa(title, LV_OPA_78, LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(title, LV_OPA_80, LV_PART_MAIN);
     lv_obj_set_style_radius(title, 16, LV_PART_MAIN);
     lv_obj_set_style_shadow_width(title, 24, LV_PART_MAIN);
     lv_obj_set_style_shadow_opa(title, LV_OPA_50, LV_PART_MAIN);

--- a/custom/ui/ui_root.c
+++ b/custom/ui/ui_root.c
@@ -62,7 +62,7 @@ ui_root_t *ui_root_create(void)
     if (root == NULL) {
         return NULL;
     }
-    lv_memset_00(root, sizeof(ui_root_t));
+    lv_memset(root, 0, sizeof(ui_root_t));
 
     root->screen = lv_screen_active();
 

--- a/custom/ui/ui_wallpaper.h
+++ b/custom/ui/ui_wallpaper.h
@@ -24,9 +24,7 @@ extern "C" {
 #endif
 
 typedef struct ui_wallpaper_t {
-    lv_obj_t *img;
-    uint8_t idx;
-    lv_timer_t *timer;
+    lv_obj_t *layer;
 } ui_wallpaper_t;
 
 ui_wallpaper_t *ui_wallpaper_attach(lv_obj_t *parent);


### PR DESCRIPTION
## Summary
- replace the deprecated LVGL allocator helper in `ui_root` with `lv_memset`
- simplify the wallpaper helper to a static gradient layer so the empty pages compile without external assets
- adjust the CCTV page styling to use a valid opacity constant supported by the ESP-IDF LVGL widgets

## Testing
- `idf.py set-target esp32p4` *(fails: command not found in container)*
- `idf.py build` *(not run: depends on missing idf.py tool)*

------
https://chatgpt.com/codex/tasks/task_e_68cb085c898c83249f83198705e90f9f