### PR TITLE
fix: adjust asset mount include path

### DIFF
--- a/custom/assets/asset_mount.c
+++ b/custom/assets/asset_mount.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-#include "custom/assets/asset_mount.h"
+#include "asset_mount.h"
 
 #include <stdbool.h>
 #include <stddef.h>


### PR DESCRIPTION
## Summary
- update the asset mount implementation to include its header via the component include directory

## Testing
- `idf.py build` *(fails: `idf.py`: command not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0e46f6908324b7f75d4037a1cf1a