### PR TITLE
feat(ui): load wallpaper image

### DIFF
--- a/custom/ui/ui_wallpaper.c
+++ b/custom/ui/ui_wallpaper.c
@@ -5,6 +5,8 @@
  */
 #include "ui_wallpaper.h"
 
+#include "custom/assets/asset_mount.h"
+
 ui_wallpaper_t *ui_wallpaper_attach(lv_obj_t *parent)
 {
     if (parent == NULL) {
@@ -33,6 +35,22 @@ ui_wallpaper_t *ui_wallpaper_attach(lv_obj_t *parent)
     lv_obj_set_style_bg_grad_dir(wallpaper->layer, LV_GRAD_DIR_VER, LV_PART_MAIN);
     lv_obj_set_style_border_width(wallpaper->layer, 0, LV_PART_MAIN);
 
+    assets_fs_init();
+
+    const char *image_path = assets_path_1();
+    if (image_path != NULL) {
+        wallpaper->image = lv_img_create(wallpaper->layer);
+        if (wallpaper->image != NULL) {
+            lv_obj_add_flag(wallpaper->image, LV_OBJ_FLAG_IGNORE_LAYOUT);
+            lv_obj_set_size(wallpaper->image, LV_PCT(100), LV_PCT(100));
+            lv_obj_center(wallpaper->image);
+            if (lv_img_set_src(wallpaper->image, image_path) != LV_RES_OK) {
+                lv_obj_del(wallpaper->image);
+                wallpaper->image = NULL;
+            }
+        }
+    }
+
     return wallpaper;
 }
 
@@ -40,6 +58,11 @@ void ui_wallpaper_detach(ui_wallpaper_t *wallpaper)
 {
     if (wallpaper == NULL) {
         return;
+    }
+
+    if (wallpaper->image != NULL) {
+        lv_obj_del(wallpaper->image);
+        wallpaper->image = NULL;
     }
 
     if (wallpaper->layer != NULL) {

--- a/custom/ui/ui_wallpaper.h
+++ b/custom/ui/ui_wallpaper.h
@@ -25,6 +25,7 @@ extern "C" {
 
 typedef struct ui_wallpaper_t {
     lv_obj_t *layer;
+    lv_obj_t *image;
 } ui_wallpaper_t;
 
 ui_wallpaper_t *ui_wallpaper_attach(lv_obj_t *parent);


### PR DESCRIPTION
## Summary
- track both the wallpaper container and image widget so the wallpaper state can be managed cleanly
- initialize the asset filesystem, load the primary wallpaper PNG with a gradient fallback, and wire it into the wallpaper layer
- dispose of the wallpaper image widget during teardown to avoid leaking LVGL objects

## Testing
- `idf.py build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0fec66848324942927c99cce28d9