### PR TITLE
fix: include asset header via component path

### DIFF
--- a/custom/ui/ui_wallpaper.c
+++ b/custom/ui/ui_wallpaper.c
@@ -5,7 +5,7 @@
  */
 #include "ui_wallpaper.h"
 
-#include "custom/assets/asset_mount.h"
+#include "assets/asset_mount.h"
 
 ui_wallpaper_t *ui_wallpaper_attach(lv_obj_t *parent)
 {


### PR DESCRIPTION
## Summary
- fix the wallpaper source to include the asset mount header from the custom component include path so it resolves during the build

## Testing
- `idf.py build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb14da49888324a0ccb6925ea88748