### PR TITLE
ci: fetch dependencies before esp-idf build

### DIFF
--- a/.github/workflows/idf-build.yml
+++ b/.github/workflows/idf-build.yml
@@ -28,6 +28,9 @@ jobs:
             ccache-${{ runner.os }}-${{ github.ref_name }}-
             ccache-${{ runner.os }}-
 
+      - name: Fetch dependencies
+        run: python3 fetch_repos.py
+
       - name: Build with ESP-IDF 5.5.x (esp32p4)
         uses: espressif/esp-idf-ci-action@v1
         with:


### PR DESCRIPTION
## Summary
- ensure the IDF CI workflow runs fetch_repos.py so external dependencies are available before building

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cb2087cfb08324b2c6f0ddc21e415e