### PR TITLE
ops(environments): fix gh api payload

### DIFF
--- a/.github/scripts/create_envs.sh
+++ b/.github/scripts/create_envs.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 owner/repo [production_reviewer_id]" >&2
+  exit 1
+fi
+
+REPO="$1"
+PRODUCTION_REVIEWER_ID="${2:-60427476}"
+
+# Staging: wait 2m, protected branches
+gh api -X PUT -H "X-GitHub-Api-Version: 2022-11-28" \
+  "repos/${REPO}/environments/staging" \
+  --input - <<JSON
+{
+  "wait_timer": 2,
+  "prevent_self_review": false,
+  "deployment_branch_policy": {
+    "protected_branches": true,
+    "custom_branch_policies": false
+  }
+}
+JSON
+
+# Production: wait 5m, prevent self-review, 1 reviewer (default repo owner)
+gh api -X PUT -H "X-GitHub-Api-Version: 2022-11-28" \
+  "repos/${REPO}/environments/production" \
+  --input - <<JSON
+{
+  "wait_timer": 5,
+  "prevent_self_review": true,
+  "deployment_branch_policy": {
+    "protected_branches": true,
+    "custom_branch_policies": false
+  },
+  "reviewers": [
+    { "type": "User", "id": ${PRODUCTION_REVIEWER_ID} }
+  ]
+}
+JSON
+echo "Created/updated environments."

--- a/.github/workflows/idf-build.yml
+++ b/.github/workflows/idf-build.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment:
+      name: staging
 
     steps:
       - name: Checkout (with submodules)

--- a/.github/workflows/webflash.yml
+++ b/.github/workflows/webflash.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -56,4 +59,5 @@ jobs:
           path: site
 
       - name: Deploy to GitHub Pages
+        id: deployment
         uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ Locally, the devcontainer auto-exports the IDF env, so `idf.py` works in any she
 - Build: `scripts/build.sh`
 - Format: `scripts/format.sh`
 
+### Environments
+We deploy with GitHub **Environments**:
+- `staging`: CI/test context
+- `production`: protected (wait timer + reviewer)
+Pages deploys to **environment `github-pages`** with a live URL on each release.
+
+Learn more: GitHub docs on [managing environments](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment), [deploying to environments](https://docs.github.com/en/actions/deployment/about-deployments/deploying-with-github-actions), and [protection rules](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environment-protection-rules).
+
 ------------
 
 


### PR DESCRIPTION
## Summary
- add a helper script to create/update staging and production environments with the desired protection rules
- wire the IDF build workflow to the staging environment and surface the GitHub Pages URL in the webflash workflow
- document the new deployment environments in the README
- update the helper script to send full JSON payloads and default the production reviewer to the repo owner (override via optional arg)

## Testing
- `bash -n .github/scripts/create_envs.sh`
- `idf.py build` *(fails: `idf.py` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb215151f883249cd655308411e12f