### PR TITLE
Disable legacy I2C driver to avoid NG conflict

### DIFF
--- a/platforms/tab5/sdkconfig
+++ b/platforms/tab5/sdkconfig
@@ -825,6 +825,7 @@ CONFIG_APPTRACE_LOCK_ENABLE=y
 #
 # Legacy I2C Driver Configurations
 #
+CONFIG_I2C_ENABLE_LEGACY_DRIVERS=n
 # CONFIG_I2C_SKIP_LEGACY_CONFLICT_CHECK is not set
 # end of Legacy I2C Driver Configurations
 


### PR DESCRIPTION
## Summary
- disable the legacy I2C driver in sdkconfig so only the NG driver is linked

## Testing
- not run (ESP-IDF toolchain is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cb274c619c8324bbeb1cd4450f7ec3