### PR TITLE
ci: fetch dependencies for esp-idf build

### DIFF
--- a/.github/workflows/idf-build.yml
+++ b/.github/workflows/idf-build.yml
@@ -15,6 +15,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Fetch third-party dependencies
+        run: python fetch_repos.py
+
       # Optional: speed up repeated builds (ccache)
       - name: Prepare ccache dir
         run: mkdir -p .ccache
@@ -33,7 +36,7 @@ jobs:
         with:
           esp_idf_version: v5.5.1
           target: esp32p4
-          path: .
+          path: platforms/tab5
           extra_docker_args: "-v ${{ github.workspace }}/.ccache:/root/.ccache -e CCACHE_DIR=/root/.ccache"
 
       - name: Upload firmware


### PR DESCRIPTION
## Summary
- run the repository's dependency fetch script before starting the ESP-IDF build job
- point the CI build at the Tab5 project directory so the esp-idf action compiles the correct target

## Testing
- not run (idf.py unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cb2bc776708324aa707b60b5ce3d24