### PR TITLE
fix: guard against legacy i2c configs

### DIFF
--- a/docs/I2C_MIGRATION.md
+++ b/docs/I2C_MIGRATION.md
@@ -53,6 +53,9 @@ APIs—do not mix in `i2c_master_cmd_begin()` or the legacy link commands.
 - If the firmware prints `CONFLICT! driver_ng is not allowed to be used with
   this old driver`, erase the flash and confirm no component still pulls in
   `driver/i2c.h`.
+- The build now fails if either `CONFIG_I2C_ENABLE_LEGACY_DRIVERS` or
+  `CONFIG_I2C_SKIP_LEGACY_CONFLICT_CHECK` is enabled; fix the configuration
+  before flashing new firmware.
 - Verify CI passed the "Enforce NG I2C usage" step; it runs `git grep` to block
   legacy includes or helper calls from landing in `main`.
 - For stubborn build issues, re-run `python3 fetch_repos.py` to make sure every

--- a/platforms/tab5/main/app_main.cpp
+++ b/platforms/tab5/main/app_main.cpp
@@ -3,12 +3,24 @@
  *
  * SPDX-License-Identifier: MIT
  */
+#include <memory>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include <sdkconfig.h>
+
 #include "hal/hal_esp32.h"
 #include <app.h>
 #include <hal/hal.h>
-#include <memory>
-#include <freertos/FreeRTOS.h>
-#include <freertos/task.h>
+
+#if defined(CONFIG_I2C_ENABLE_LEGACY_DRIVERS) && CONFIG_I2C_ENABLE_LEGACY_DRIVERS
+#error "Legacy ESP-IDF I2C driver is unsupported; disable CONFIG_I2C_ENABLE_LEGACY_DRIVERS."
+#endif
+
+#if defined(CONFIG_I2C_SKIP_LEGACY_CONFLICT_CHECK) && CONFIG_I2C_SKIP_LEGACY_CONFLICT_CHECK
+#error "Do not enable CONFIG_I2C_SKIP_LEGACY_CONFLICT_CHECK; leave it set to n."
+#endif
 
 extern "C" void app_main(void)
 {

--- a/tests/test_check_legacy_i2c.py
+++ b/tests/test_check_legacy_i2c.py
@@ -78,6 +78,32 @@ class CheckLegacyI2CTests(unittest.TestCase):
             finding = result.findings[0]
             self.assertIn("legacy i2c_master_cmd_begin", finding.reason)
 
+    def test_flags_legacy_driver_enabled_in_sdkconfig(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = Path(tmpdir) / "sdkconfig"
+            cfg_path.write_text("CONFIG_I2C_ENABLE_LEGACY_DRIVERS=y\n", encoding="utf-8")
+
+            result = self.module.scan_paths([Path(tmpdir)])
+
+            self.assertEqual(result.files_scanned, 1)
+            self.assertEqual(len(result.findings), 1)
+            finding = result.findings[0]
+            self.assertEqual(finding.path, cfg_path)
+            self.assertIn("legacy I2C driver enabled", finding.reason)
+
+    def test_flags_conflict_check_disabled_in_sdkconfig(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = Path(tmpdir) / "sdkconfig.defaults"
+            cfg_path.write_text("CONFIG_I2C_SKIP_LEGACY_CONFLICT_CHECK=y\n", encoding="utf-8")
+
+            result = self.module.scan_paths([Path(tmpdir)])
+
+            self.assertEqual(result.files_scanned, 1)
+            self.assertEqual(len(result.findings), 1)
+            finding = result.findings[0]
+            self.assertEqual(finding.path, cfg_path)
+            self.assertIn("legacy driver conflict check disabled", finding.reason)
+
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
     unittest.main()


### PR DESCRIPTION
## Summary
- add compile-time guards to stop builds when legacy I2C drivers are enabled
- extend the legacy I2C checker to scan sdkconfig files for forbidden settings
- document the new safeguards and cover them with unit tests

## Testing
- python -m unittest tests/test_check_legacy_i2c.py
- python scripts/check_legacy_i2c.py
- npx markdownlint-cli@latest docs/I2C_MIGRATION.md


------
https://chatgpt.com/codex/tasks/task_e_68cb2f962970832484589b3f2a6361b5