### PR TITLE
fix: disable sd card usage to avoid boot loop

### DIFF
--- a/app/apps/app_launcher/view/panel_sd_card.cpp
+++ b/app/apps/app_launcher/view/panel_sd_card.cpp
@@ -52,7 +52,7 @@ public:
             _label_msg->setText("Scanning SD Card ...");
         } else {
             _label_msg->setTextColor(lv_color_hex(0xFD4444));
-            _label_msg->setText("SD Card not mounted.\n\nPlease insert SD Card and reboot.");
+            _label_msg->setText("SD Card support is disabled.\n\nBuilt-in assets will be used.");
         }
     }
 

--- a/custom/assets/asset_mount.c
+++ b/custom/assets/asset_mount.c
@@ -233,21 +233,7 @@ void assets_fs_init(void)
 #endif
 
 #if defined(ESP_PLATFORM)
-    sdmmc_host_t host                        = SDMMC_HOST_DEFAULT();
-    sdmmc_slot_config_t slot_config          = SDMMC_SLOT_CONFIG_DEFAULT();
-    esp_vfs_fat_sdmmc_mount_config_t mnt_cfg = {
-        .format_if_mount_failed = false,
-        .max_files              = 4,
-        .allocation_unit_size   = 16 * 1024,
-    };
-    sdmmc_card_t *card = NULL;
-    esp_err_t err      = esp_vfs_fat_sdmmc_mount(SD_MOUNT_POINT, &host, &slot_config, &mnt_cfg, &card);
-    if (err == ESP_OK) {
-        s_sd_ok = true;
-        ASSET_LOGI(k_tag, "SD mounted at %s", SD_MOUNT_POINT);
-    } else {
-        ASSET_LOGW(k_tag, "SD not mounted (err=0x%x). Proceeding without SD.", (unsigned int)err);
-    }
+    ASSET_LOGW(k_tag, "SD card mounting disabled; using internal assets only");
 #else
     ASSET_LOGI(k_tag, "Desktop build: using host filesystem without SD mount");
 #endif

--- a/platforms/tab5/main/hal/hal_esp32.cpp
+++ b/platforms/tab5/main/hal/hal_esp32.cpp
@@ -267,50 +267,19 @@ void HalEsp32::update_system_time()
 /* -------------------------------------------------------------------------- */
 /*                                   SD Card                                  */
 /* -------------------------------------------------------------------------- */
-#include <dirent.h>
-#include <sys/types.h>
-
 bool HalEsp32::isSdCardMounted()
 {
-    return true;
+    return _sd_card_mounted;
 }
 
 std::vector<hal::HalBase::FileEntry_t> HalEsp32::scanSdCard(const std::string& dirPath)
 {
-    std::vector<hal::HalBase::FileEntry_t> file_entries;
+    (void)dirPath;
+    _sd_card_mounted = false;
 
-    mclog::tagInfo(_tag, "init sd card");
-    if (bsp_sdcard_init("/sd", 25) != ESP_OK) {
-        mclog::error("failed to mount sd card");
-        return file_entries;
-    }
+    mclog::tagWarn(_tag, "SD card access disabled; skipping scan request");
 
-    std::string target_path = "/sd/" + dirPath;
-
-    DIR* dir = opendir(target_path.c_str());
-    if (dir == nullptr) {
-        mclog::error("failed to open directory: {}", target_path);
-        return file_entries;
-    }
-
-    struct dirent* entry;
-    while ((entry = readdir(dir)) != nullptr) {
-        if (std::string(entry->d_name) == "." || std::string(entry->d_name) == "..") {
-            continue;
-        }
-
-        hal::HalBase::FileEntry_t file_entry;
-        file_entry.name  = entry->d_name;
-        file_entry.isDir = (entry->d_type == DT_DIR);
-        file_entries.push_back(file_entry);
-    }
-
-    closedir(dir);
-
-    mclog::tagInfo(_tag, "deinit sd card");
-    bsp_sdcard_deinit("/sd");
-
-    return file_entries;
+    return {};
 }
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary
- stop mounting the SD card during asset init and rely on built-in wallpapers
- disable SD card scanning in the ESP32 HAL so the launcher no longer tries to access it
- update the SD card panel copy to explain that support is disabled

## Testing
- idf.py build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbbbc109388324a6d96aaa5097b57c