### PR TITLE
Refine nav rail swipe detection

### DIFF
--- a/custom/ui/ui_nav_rail.h
+++ b/custom/ui/ui_nav_rail.h
@@ -5,6 +5,8 @@
  */
 #pragma once
 
+#include <stdbool.h>
+
 #ifdef __has_include
 #if __has_include("lvgl.h")
 #ifndef LV_LVGL_H_INCLUDE_SIMPLE
@@ -40,6 +42,9 @@ ui_nav_rail_t *ui_nav_rail_create(lv_obj_t *parent, ui_nav_rail_callback_t callb
 void ui_nav_rail_destroy(ui_nav_rail_t *rail);
 void ui_nav_rail_set_active(ui_nav_rail_t *rail, ui_nav_page_t page);
 lv_obj_t *ui_nav_rail_get_container(ui_nav_rail_t *rail);
+void ui_nav_rail_show(ui_nav_rail_t *rail, bool animate);
+void ui_nav_rail_hide(ui_nav_rail_t *rail, bool animate);
+bool ui_nav_rail_is_visible(const ui_nav_rail_t *rail);
 
 #ifdef __cplusplus
 }

--- a/custom/ui/ui_root.c
+++ b/custom/ui/ui_root.c
@@ -15,7 +15,15 @@ struct ui_root_t {
     ui_nav_rail_t *nav;
     lv_obj_t *pages[UI_NAV_PAGE_COUNT];
     ui_nav_page_t active;
+    lv_obj_t *nav_scrim;
+    lv_obj_t *gesture_zone;
+    bool edge_swipe_active;
+    bool edge_swipe_triggered;
+    lv_coord_t edge_swipe_start_x;
 };
+
+static void ui_root_hide_nav(ui_root_t *root, bool animate);
+static void ui_root_show_nav(ui_root_t *root, bool animate);
 
 static void ui_root_nav_changed(ui_nav_rail_t *rail, ui_nav_page_t page, void *user_data)
 {
@@ -26,6 +34,90 @@ static void ui_root_nav_changed(ui_nav_rail_t *rail, ui_nav_page_t page, void *u
     }
 
     ui_root_show_page(root, page);
+    ui_root_hide_nav(root, true);
+}
+
+static void ui_root_scrim_event_cb(lv_event_t *event)
+{
+    if (event == NULL) {
+        return;
+    }
+
+    if (lv_event_get_code(event) != LV_EVENT_CLICKED) {
+        return;
+    }
+
+    ui_root_t *root = (ui_root_t *)lv_event_get_user_data(event);
+    ui_root_hide_nav(root, true);
+}
+
+static void ui_root_edge_gesture_cb(lv_event_t *event)
+{
+    if (event == NULL) {
+        return;
+    }
+
+    ui_root_t *root = (ui_root_t *)lv_event_get_user_data(event);
+    if (root == NULL || root->nav == NULL) {
+        return;
+    }
+
+    lv_event_code_t code = lv_event_get_code(event);
+    lv_indev_t *indev    = lv_indev_get_act();
+    switch (code) {
+        case LV_EVENT_PRESSED:
+            root->edge_swipe_active    = true;
+            root->edge_swipe_triggered = false;
+            if (indev != NULL) {
+                lv_point_t point;
+                lv_indev_get_point(indev, &point);
+                root->edge_swipe_start_x = point.x;
+            } else {
+                root->edge_swipe_start_x = 0;
+            }
+            break;
+        case LV_EVENT_PRESSING:
+            if (!root->edge_swipe_active || root->edge_swipe_triggered || indev == NULL) {
+                break;
+            }
+            {
+                lv_point_t point;
+                lv_indev_get_point(indev, &point);
+                if ((point.x - root->edge_swipe_start_x) > 24) {
+                    root->edge_swipe_triggered = true;
+                    ui_root_show_nav(root, true);
+                }
+            }
+            break;
+        case LV_EVENT_RELEASED:
+        case LV_EVENT_PRESS_LOST:
+            root->edge_swipe_active    = false;
+            root->edge_swipe_triggered = false;
+            break;
+        default:
+            break;
+    }
+}
+
+static void ui_root_nav_gesture_cb(lv_event_t *event)
+{
+    if (event == NULL) {
+        return;
+    }
+
+    if (lv_event_get_code(event) != LV_EVENT_GESTURE) {
+        return;
+    }
+
+    ui_root_t *root = (ui_root_t *)lv_event_get_user_data(event);
+    if (root == NULL) {
+        return;
+    }
+
+    lv_indev_t *indev = lv_indev_get_act();
+    if (indev != NULL && lv_indev_get_gesture_dir(indev) == LV_DIR_LEFT) {
+        ui_root_hide_nav(root, true);
+    }
 }
 
 static void ui_root_hide_all_overlays(ui_root_t *root)
@@ -74,7 +166,41 @@ ui_root_t *ui_root_create(void)
 
     ui_root_create_pages(root);
 
+    root->nav_scrim = lv_obj_create(root->screen);
+    if (root->nav_scrim != NULL) {
+        lv_obj_remove_style_all(root->nav_scrim);
+        lv_obj_set_size(root->nav_scrim, LV_PCT(100), LV_PCT(100));
+        lv_obj_add_flag(root->nav_scrim, LV_OBJ_FLAG_IGNORE_LAYOUT);
+        lv_obj_add_flag(root->nav_scrim, LV_OBJ_FLAG_CLICKABLE);
+        lv_obj_add_flag(root->nav_scrim, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_set_style_bg_color(root->nav_scrim, lv_color_hex(0x04060a), LV_PART_MAIN);
+        lv_obj_set_style_bg_opa(root->nav_scrim, LV_OPA_40, LV_PART_MAIN);
+        lv_obj_add_event_cb(root->nav_scrim, ui_root_scrim_event_cb, LV_EVENT_CLICKED, root);
+    }
+
+    root->gesture_zone = lv_obj_create(root->screen);
+    if (root->gesture_zone != NULL) {
+        lv_obj_remove_style_all(root->gesture_zone);
+        lv_obj_set_size(root->gesture_zone, 96, LV_PCT(100));
+        lv_obj_align(root->gesture_zone, LV_ALIGN_LEFT_MID, 0, 0);
+        lv_obj_add_flag(root->gesture_zone, LV_OBJ_FLAG_IGNORE_LAYOUT);
+        lv_obj_add_flag(root->gesture_zone, LV_OBJ_FLAG_CLICKABLE);
+        lv_obj_set_style_bg_opa(root->gesture_zone, LV_OPA_TRANSP, LV_PART_MAIN);
+        lv_obj_add_event_cb(root->gesture_zone, ui_root_edge_gesture_cb, LV_EVENT_PRESSED, root);
+        lv_obj_add_event_cb(root->gesture_zone, ui_root_edge_gesture_cb, LV_EVENT_PRESSING, root);
+        lv_obj_add_event_cb(root->gesture_zone, ui_root_edge_gesture_cb, LV_EVENT_RELEASED, root);
+        lv_obj_add_event_cb(root->gesture_zone, ui_root_edge_gesture_cb, LV_EVENT_PRESS_LOST, root);
+    }
+
     lv_obj_move_foreground(ui_nav_rail_get_container(root->nav));
+    if (root->nav_scrim != NULL) {
+        lv_obj_move_background(root->nav_scrim);
+    }
+    if (root->gesture_zone != NULL) {
+        lv_obj_move_foreground(root->gesture_zone);
+    }
+    ui_nav_rail_hide(root->nav, false);
+    lv_obj_add_event_cb(ui_nav_rail_get_container(root->nav), ui_root_nav_gesture_cb, LV_EVENT_GESTURE, root);
     ui_root_hide_all_overlays(root);
     root->active = UI_NAV_PAGE_DEFAULT;
 
@@ -97,6 +223,16 @@ void ui_root_destroy(ui_root_t *root)
     if (root->nav != NULL) {
         ui_nav_rail_destroy(root->nav);
         root->nav = NULL;
+    }
+
+    if (root->gesture_zone != NULL) {
+        lv_obj_del(root->gesture_zone);
+        root->gesture_zone = NULL;
+    }
+
+    if (root->nav_scrim != NULL) {
+        lv_obj_del(root->nav_scrim);
+        root->nav_scrim = NULL;
     }
 
     lv_free(root);
@@ -131,6 +267,38 @@ void ui_root_show_page(ui_root_t *root, ui_nav_page_t page)
     lv_obj_move_foreground(ui_nav_rail_get_container(root->nav));
     ui_nav_rail_set_active(root->nav, page);
     root->active = page;
+}
+
+static void ui_root_hide_nav(ui_root_t *root, bool animate)
+{
+    if (root == NULL || root->nav == NULL) {
+        return;
+    }
+
+    if (root->nav_scrim != NULL) {
+        lv_obj_add_flag(root->nav_scrim, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_move_background(root->nav_scrim);
+    }
+
+    ui_nav_rail_hide(root->nav, animate);
+}
+
+static void ui_root_show_nav(ui_root_t *root, bool animate)
+{
+    if (root == NULL || root->nav == NULL) {
+        return;
+    }
+
+    if (!ui_nav_rail_is_visible(root->nav)) {
+        ui_nav_rail_show(root->nav, animate);
+    }
+
+    if (root->nav_scrim != NULL) {
+        lv_obj_clear_flag(root->nav_scrim, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_move_foreground(root->nav_scrim);
+    }
+
+    lv_obj_move_foreground(ui_nav_rail_get_container(root->nav));
 }
 
 ui_nav_page_t ui_root_get_active(const ui_root_t *root)


### PR DESCRIPTION
## Summary
- broaden the navigation rail gesture zone to cover the full left edge and detect swipes through press tracking
- add a helper that reveals the rail alongside its scrim so show/hide calls keep layering consistent
- recalculate the rail’s hidden offset when its size changes to keep the show/hide utilities reliable

## Testing
- `idf.py set-target esp32p4` *(fails: idf.py not available in environment)*
- `idf.py build` *(fails: idf.py not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc01e37b98832489d097c507e3bcd3