### PR TITLE
Fix custom asset packaging for Tab5 and desktop

### DIFF
--- a/custom/assets/asset_mount.c
+++ b/custom/assets/asset_mount.c
@@ -182,9 +182,13 @@ static void lv_fs_if_init(void)
 #define ASSET_LOGW(tag, fmt, ...) LV_LOG_WARN(fmt, ##__VA_ARGS__)
 #endif
 
-#define SD_ASSET_ROOT       "/sdcard/custom/assets"
+#define SD_ASSET_ROOT "/sdcard/custom/assets"
+#if !defined(ESP_PLATFORM) && defined(LV_FS_IF_POSIX) && (LV_FS_IF_POSIX != '\0')
+#define INTERNAL_ASSET_ROOT "./custom/assets"
+#else
 #define INTERNAL_ASSET_ROOT "/custom/assets"
-#define BG_RELATIVE         "/bg"
+#endif
+#define BG_RELATIVE "/bg"
 
 static const char *k_tag = "assets";
 

--- a/platforms/tab5/main/CMakeLists.txt
+++ b/platforms/tab5/main/CMakeLists.txt
@@ -21,3 +21,7 @@ file(GLOB_RECURSE MY_HAL_SRCS
 idf_component_register(SRCS "app_main.cpp" ${APP_LAYER_SRCS} ${MY_HAL_SRCS}
                     INCLUDE_DIRS "." ${APP_LAYER_INCS}
                     EMBED_TXTFILES "../audio/canon_in_d.mp3" "../audio/startup_sfx.mp3" "../audio/shutdown_sfx.mp3")
+
+set(CUSTOM_ASSETS_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../custom/assets")
+get_filename_component(CUSTOM_ASSETS_DIR "${CUSTOM_ASSETS_DIR}" REALPATH)
+spiffs_create_partition_image(storage "${CUSTOM_ASSETS_DIR}" FLASH_IN_PROJECT)


### PR DESCRIPTION
## Summary
- embed the custom asset bundle into the Tab5 storage SPIFFS image during the ESP-IDF build
- make the desktop filesystem shim resolve wallpaper PNGs from the repository when LV_FS_IF_POSIX is enabled

## Testing
- ./scripts/build.sh *(fails: `IDF_PATH` unbound in container)*
- /tmp/test_asset_mount

------
https://chatgpt.com/codex/tasks/task_e_68cc35add8188324b4f21a5dc7e81003