### PR TITLE
chore(tooling): add clang tidy config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,35 @@
+---
+Checks: >
+  -*,
+  clang-diagnostic-*,
+  clang-analyzer-*,
+  bugprone-*,
+  performance-*,
+  readability-*,
+  modernize-*
+WarningsAsErrors: >
+  clang-diagnostic-*,
+  bugprone-*,
+  performance-*,
+  readability-*,
+  modernize-*
+HeaderFilterRegex: '^(app|custom|platforms|tests)/'
+AnalyzeTemporaryDtors: true
+FormatStyle: file
+CheckOptions:
+  - key:             readability-identifier-naming.ClassCase
+    value:           PascalCase
+  - key:             readability-identifier-naming.StructCase
+    value:           PascalCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           PascalCase
+  - key:             readability-identifier-naming.EnumConstantCase
+    value:           UPPER_CASE
+  - key:             readability-identifier-naming.FunctionCase
+    value:           snake_case
+  - key:             readability-identifier-naming.MethodCase
+    value:           PascalCase
+  - key:             readability-identifier-naming.VariableCase
+    value:           lower_case
+  - key:             readability-identifier-naming.GlobalConstantCase
+    value:           UPPER_CASE


### PR DESCRIPTION
## Summary
- add a project-wide `.clang-tidy` configuration covering bugprone, performance, readability, modernize, and analyzer checks
- scope the analysis to project headers and record identifier naming expectations to match the documented conventions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc6925c99483248effdc821b04c280