### PR TITLE
chore: align editorconfig defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,12 +5,10 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-[*.{c,cpp,cxx,h,hpp,hxx}]
 indent_style = space
 indent_size = 4
 
-[*.{py,cmake,txt}]
+[*.{c,cpp,cxx,h,hpp,hxx}]
 indent_style = space
 indent_size = 4
 


### PR DESCRIPTION
## Summary
- set repository-wide defaults in .editorconfig for charset, line endings, and indentation
- remove the obsolete Python/CMake/TXT block now covered by the global defaults

## Testing
- idf.py build *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc692b01808324a9f1e503918527e0