### PR TITLE
Add clang-format lint check workflow

### DIFF
--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -1,0 +1,57 @@
+name: Lint Check
+
+on:
+  pull_request:
+    paths:
+      - '**.c'
+      - '**.C'
+      - '**.cc'
+      - '**.cpp'
+      - '**.cxx'
+      - '**.c++'
+      - '**.h'
+      - '**.H'
+      - '**.hh'
+      - '**.hpp'
+      - '**.hxx'
+      - '**.h++'
+  push:
+    branches:
+      - main
+    paths:
+      - '**.c'
+      - '**.C'
+      - '**.cc'
+      - '**.cpp'
+      - '**.cxx'
+      - '**.c++'
+      - '**.h'
+      - '**.H'
+      - '**.hh'
+      - '**.hpp'
+      - '**.hxx'
+      - '**.h++'
+  workflow_dispatch:
+
+jobs:
+  clang-format:
+    name: clang-format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup C++ tooling
+        uses: aminya/setup-cpp@v1
+        with:
+          clangformat: 13
+
+      - name: Verify formatting
+        shell: bash
+        run: |
+          files=$(git ls-files '*.c' '*.C' '*.cc' '*.cpp' '*.cxx' '*.c++' '*.h' '*.H' '*.hh' '*.hpp' '*.hxx' '*.h++')
+          if [[ -z "$files" ]]; then
+            echo 'No tracked C/C++ files to check.'
+            exit 0
+          fi
+          clang-format --dry-run --Werror $files


### PR DESCRIPTION
## Summary
- add a lint-check GitHub Action that installs clang-format via setup-cpp and runs a dry-run formatting check on tracked C/C++ files

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cc693e73b08324862c81eac5e037e1