### PR TITLE
Add clang-format pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v17.0.6
+    hooks:
+      - id: clang-format

--- a/README.md
+++ b/README.md
@@ -73,10 +73,22 @@ Using stuff from base code, we get and publish these states to HA:
   - Quick toggles: Do Not Disturb, Auto-brightness  
   - Sleep & restart controls
 
-- **Developer Experience**  
-  - Modular LVGL components (`ui_home`, `ui_rooms`, `ui_security`, `ui_control_center`)  
-  - Design tokens & wireframes in `docs/` for AI/assistants  
-  - CI-friendly (ESP-IDF build, firmware artifacts)  
+- **Developer Experience**
+  - Modular LVGL components (`ui_home`, `ui_rooms`, `ui_security`, `ui_control_center`)
+  - Design tokens & wireframes in `docs/` for AI/assistants
+  - CI-friendly (ESP-IDF build, firmware artifacts)
+
+## 🧹 Formatting & Git Hooks
+
+Install the repo's clang-format hook locally with [pre-commit](https://pre-commit.com/):
+
+```bash
+pip install pre-commit  # once per machine
+pre-commit install
+```
+
+Running `pre-commit install` configures Git to automatically run clang-format on
+changed files before each commit.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a `.pre-commit-config.yaml` that runs clang-format via pre-commit
- update the README with instructions to enable the hook locally

## Testing
- `idf.py build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc69448fdc832491c53b0e3e280098