### PR TITLE
ci: add autofix lint workflow

### DIFF
--- a/.github/workflows/autofix-lint.yml
+++ b/.github/workflows/autofix-lint.yml
@@ -1,0 +1,54 @@
+name: Autofix lint
+
+on:
+  workflow_dispatch:
+  pull_request_target:
+    types:
+      - labeled
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  autofix:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_target' &&
+       github.event.action == 'labeled' &&
+       github.event.label.name == 'autofix-lint')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup C++ toolchain
+        uses: aminya/setup-cpp@v1
+        with:
+          compiler: llvm
+
+      - name: Run format fixer
+        run: ./scripts/format.sh
+
+      - name: Commit changes
+        id: commit
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "style: apply lint autofix"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Push changes
+        if: steps.commit.outputs.changed == 'true'
+        run: git push


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that can be triggered manually or by the autofix-lint label
- run the repo formatting fixer inside the workflow and auto-commit/push results

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc69345ff0832483ad80f341240554