### PR TITLE
Speed up rooms_page_test: slim LVGL, enable ccache+unity build, use Ninja & system GTest, add CI timeout

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -1,0 +1,49 @@
+name: Host Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Use system GTest (fast) and tools
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build cmake ccache libgtest-dev
+          # Build GTest if headers/libs not prebuilt on the runner image
+          sudo cmake -S /usr/src/googletest -B /usr/src/googletest/build
+          sudo cmake --build /usr/src/googletest/build -j
+          sudo cp -a /usr/src/googletest/build/lib/* /usr/local/lib/
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ccache
+          key: ccache-host-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt', 'custom/**', 'tests/**') }}
+          restore-keys: |
+            ccache-host-${{ runner.os }}-
+
+      - name: Configure (Ninja + ccache + unity)
+        env:
+          CCACHE_DIR: ~/.cache/ccache
+        run: |
+          cmake -S tests -B tests/build \
+            -G Ninja \
+            -DCMAKE_UNITY_BUILD=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DROMS_ONLY=ON
+
+      - name: Build rooms_page_test
+        run: cmake --build tests/build --target rooms_page_test -j
+
+      - name: Run tests
+        run: ctest --test-dir tests/build --output-on-failure --timeout 60

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,17 @@
+{
+  "version": 5,
+  "configurePresets": [
+    {
+      "name": "tests-ninja-fast",
+      "displayName": "Host tests (Ninja/ccache/unity)",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/tests/build",
+      "cacheVariables": {
+        "CMAKE_UNITY_BUILD": "ON",
+        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
+        "ROMS_ONLY": "ON"
+      }
+    }
+  ]
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.20)
+project(host_tests C CXX)
+
+# Fast compile: unity + low optimization
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_UNITY_BUILD ON)
+set(CMAKE_BUILD_TYPE Debug)
+add_compile_options(-w)
+
+# Option to build only the rooms page test
+option(ROMS_ONLY "Build only Rooms Page tests" ON)
+
+# ---- Minimal LVGL: headless, small ----
+add_library(lvgl_config INTERFACE)
+target_compile_definitions(lvgl_config INTERFACE
+  LV_CONF_INCLUDE_SIMPLE
+)
+target_include_directories(lvgl_config INTERFACE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
+include(FetchContent)
+FetchContent_Declare(lvgl
+  GIT_REPOSITORY https://github.com/lvgl/lvgl.git
+  GIT_TAG v9.1.0
+)
+FetchContent_MakeAvailable(lvgl)
+if (TARGET lvgl)
+  set_property(TARGET lvgl PROPERTY UNITY_BUILD OFF)
+  target_link_libraries(lvgl PUBLIC lvgl_config)
+endif()
+
+# Your UI code under test (keep this minimal!)
+add_library(ui_rooms_under_test
+  ../custom/ui/pages/ui_page_rooms.c
+  ../custom/ui/ui_wallpaper.c
+)
+target_include_directories(ui_rooms_under_test PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/../custom/ui
+  ${CMAKE_CURRENT_SOURCE_DIR}/../custom/ui/pages
+)
+target_link_libraries(ui_rooms_under_test PUBLIC lvgl::lvgl lvgl_config)
+
+# ---- GoogleTest from system packages ----
+find_package(GTest QUIET)
+if (NOT GTest_FOUND)
+  message(STATUS "System GTest not found; falling back to FetchContent (slower).")
+  include(FetchContent)
+  FetchContent_Declare(gtest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG v1.14.0
+  )
+  FetchContent_MakeAvailable(gtest)
+endif()
+
+# ---- Rooms page test ----
+add_executable(rooms_page_test
+  ui/test_rooms_snapshot.cpp
+)
+target_link_libraries(rooms_page_test PRIVATE
+  ui_rooms_under_test
+  GTest::gtest GTest::gtest_main
+)
+
+enable_testing()
+add_test(NAME rooms_page_test COMMAND rooms_page_test)

--- a/tests/lv_conf.h
+++ b/tests/lv_conf.h
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#pragma once
+
+#include "lv_conf_host.h"

--- a/tests/lv_conf_host.h
+++ b/tests/lv_conf_host.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#pragma once
+
+#include "../lv_conf.h"
+
+#undef LV_USE_OBJ_ID
+#define LV_USE_OBJ_ID 0
+
+#undef LV_USE_OBJ_ID_BUILTIN
+#define LV_USE_OBJ_ID_BUILTIN 0
+
+#undef LV_USE_SDL
+#define LV_USE_SDL 0
+
+#undef LV_USE_LIBPNG
+#define LV_USE_LIBPNG 0
+
+#undef LV_USE_DEMO_WIDGETS
+#define LV_USE_DEMO_WIDGETS 0
+
+#undef LV_USE_DEMO_BENCHMARK
+#define LV_USE_DEMO_BENCHMARK 0
+
+#undef LV_USE_DEMO_STRESS
+#define LV_USE_DEMO_STRESS 0

--- a/tests/ui/test_rooms_snapshot.cpp
+++ b/tests/ui/test_rooms_snapshot.cpp
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include <gtest/gtest.h>
+
+extern "C"
+{
+#include "lvgl.h"
+#include "ui_page_rooms.h"
+}
+
+namespace
+{
+
+    void FlushNoop(lv_display_t* display, const lv_area_t* area, uint8_t* px_map)
+    {
+        LV_UNUSED(area);
+        LV_UNUSED(px_map);
+        lv_display_flush_ready(display);
+    }
+
+}  // namespace
+
+TEST(RoomsPage, CreatesAndRenders)
+{
+    lv_init();
+
+    constexpr uint32_t kHorRes      = 320;
+    constexpr uint32_t kVerRes      = 180;
+    constexpr uint32_t kBufferLines = 20;
+
+    static lv_color_t    buffer[kHorRes * kBufferLines];
+    static lv_draw_buf_t draw_buffer;
+    lv_result_t          init_result = lv_draw_buf_init(
+        &draw_buffer, kHorRes, kBufferLines, LV_COLOR_FORMAT_NATIVE, 0, buffer, sizeof(buffer));
+    ASSERT_EQ(init_result, LV_RESULT_OK);
+
+    lv_display_t* display = lv_display_create(kHorRes, kVerRes);
+    ASSERT_NE(display, nullptr);
+    lv_display_set_draw_buffers(display, &draw_buffer, nullptr);
+    lv_display_set_flush_cb(display, FlushNoop);
+    lv_display_set_default(display);
+
+    lv_obj_t* screen = lv_screen_active();
+    lv_obj_t* page   = ui_page_rooms_create(screen);
+    ASSERT_NE(page, nullptr);
+
+    for (int i = 0; i < 5; ++i)
+    {
+        lv_tick_inc(5);
+        lv_timer_handler();
+    }
+
+    SUCCEED();
+}


### PR DESCRIPTION
## Summary
- add a lightweight host-only CMake project that fetches LVGL, wires in the rooms UI sources, and provides a focused snapshot test harness
- supply a minimal LVGL config override for host builds and expose a Ninja/ccache preset for quick local iteration
- run the rooms snapshot test in CI via a new GitHub Actions workflow that installs Ninja, primes ccache, and enforces a timeout

## Testing
- `cmake -S tests -B tests/build -G Ninja -DCMAKE_UNITY_BUILD=ON -DROMS_ONLY=ON`
- `cmake --build tests/build --target rooms_page_test -j`
- `ctest --test-dir tests/build --output-on-failure --timeout 60`


------
https://chatgpt.com/codex/tasks/task_e_68cc76fea7a08324a1cc5e31ab2c3b4b