### PR TITLE
fix: store rooms content container

### DIFF
--- a/custom/ui/pages/ui_page_rooms.c
+++ b/custom/ui/pages/ui_page_rooms.c
@@ -350,6 +350,8 @@ static lv_obj_t* create_content(lv_obj_t* page, ui_page_rooms_ctx_t* ctx)
     lv_obj_set_flex_flow(content, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(content, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
 
+    ctx->content = content;
+
     ctx->toolbar = lv_obj_create(content);
     toolbar_style_init(ctx->toolbar);
 


### PR DESCRIPTION
## Summary
- assign the rooms page content container to the page context before creating the toolbar and cards so the grid builds under the correct parent

## Testing
- idf.py build

------
https://chatgpt.com/codex/tasks/task_e_68cc801ee8ec8324b176ec7a567f6222