### PR TITLE
chore(fetch): refresh dependencies in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Optional:
 
         git clone https://github.com/baba-dev/M5Tab5-UserDemo.git
    cd M5Tab5-UserDemo
-   python fetch_repos.py  # fetch M5 & LVGL components
+   python fetch_repos.py  # fetch or update M5 & LVGL components
 
 2. **Set ESP32-P4 target**
 

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -6,7 +6,7 @@
   `release-v5.4` toolchain to ensure the project uses the NG I²C driver stack
   exclusively.
 - Run `python3 fetch_repos.py` before building so that managed components are
-  pulled into the workspace.
+  pulled into the workspace or refreshed to the pinned revisions.
 
 ## Build checklist
 

--- a/fetch_repos.py
+++ b/fetch_repos.py
@@ -1,21 +1,53 @@
+"""Fetch dependent repositories defined in repos.json."""
+
+import json
 import os
 import subprocess
-import json
+from pathlib import Path
+
+
+def _run_git(args):
+    subprocess.run(['git', *args], check=True)
+
+
+def _maybe_update_submodules(repo_path: Path) -> None:
+    if (repo_path / '.gitmodules').is_file():
+        _run_git(['-C', str(repo_path), 'submodule', 'update', '--init', '--recursive'])
 
 
 def clone_or_update_repo(repo_url, path, branch):
-    command = []
-    command.append('git')
-    command.append('clone')
-    
+    repo_path = Path(path)
+
+    if repo_path.is_dir():
+        _run_git(['-C', str(repo_path), 'fetch', '--prune'])
+
+        if branch:
+            _run_git(['-C', str(repo_path), 'checkout', branch])
+
+            remote_ref = subprocess.run(
+                ['git', '-C', str(repo_path), 'show-ref', '--verify', f'refs/remotes/origin/{branch}'],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+
+            if remote_ref.returncode == 0:
+                _run_git(['-C', str(repo_path), 'reset', '--hard', f'origin/{branch}'])
+        else:
+            _run_git(['-C', str(repo_path), 'pull', '--ff-only'])
+
+        _maybe_update_submodules(repo_path)
+        return
+
+    command = ['clone']
+
     if branch:
-        command.append('-b')
-        command.append(branch)
+        command.extend(['-b', branch])
 
-    command.append(repo_url)
-    command.append(path)
+    command.extend([repo_url, str(repo_path)])
 
-    subprocess.run(command)
+    _run_git(command)
+    _maybe_update_submodules(repo_path)
 
 def main():
     script_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
## Summary
- detect existing dependency checkouts in `fetch_repos.py`
- reuse the working tree with `git fetch`, checkout/reset, and submodule updates
- document that `fetch_repos.py` refreshes pinned revisions in the README and dev setup guide

## Testing
- python -m compileall fetch_repos.py
- npx --yes markdownlint-cli@0.39.0 docs/DEV_SETUP.md

------
https://chatgpt.com/codex/tasks/task_e_68cc86f5edc0832495a9f0214460de09