### PR TITLE
fix: handle legacy i2c findings outside root

### DIFF
--- a/scripts/check_legacy_i2c.py
+++ b/scripts/check_legacy_i2c.py
@@ -240,7 +240,11 @@ def scan_paths(paths: Sequence[Path]) -> ScanResult:
 
 
 def _format_finding(finding: Finding, root: Path) -> str:
-    relative_path = finding.path.resolve().relative_to(root)
+    resolved_path = finding.path.resolve()
+    try:
+        relative_path = resolved_path.relative_to(root)
+    except ValueError:
+        relative_path = resolved_path
     return (
         f"{relative_path}:{finding.line_no}: {finding.reason}\n"
         f"    {finding.line}"

--- a/tests/test_check_legacy_i2c.py
+++ b/tests/test_check_legacy_i2c.py
@@ -120,6 +120,17 @@ class CheckLegacyI2CTests(unittest.TestCase):
             self.assertEqual(finding.path, cfg_path)
             self.assertIn("legacy driver conflict check still enabled", finding.reason)
 
+    def test_formatter_handles_paths_outside_root(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            src_path = Path(tmpdir) / "legacy.c"
+            src_path.write_text('#include "driver/i2c.h"\n', encoding="utf-8")
+
+            result = self.module.scan_paths([Path(tmpdir)])
+
+            self.assertEqual(len(result.findings), 1)
+            formatted = self.module._format_finding(result.findings[0], self.module.REPO_ROOT)
+            self.assertIn(str(src_path.resolve()), formatted)
+
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
     unittest.main()


### PR DESCRIPTION
## Summary
- wrap check_legacy_i2c formatter relative_to call in a ValueError guard and fall back to absolute paths
- add a regression test ensuring formatter handles findings discovered outside of the configured root

## Testing
- python -m pytest tests/test_check_legacy_i2c.py

------
https://chatgpt.com/codex/tasks/task_e_68cc86fb82348324bcf7ca03fd612516