### PR TITLE
fix: use valid icon for CCTV room card

### DIFF
--- a/custom/ui/pages/ui_page_cctv.c
+++ b/custom/ui/pages/ui_page_cctv.c
@@ -114,7 +114,7 @@ static lv_obj_t* ui_page_create_content(lv_obj_t* page, const char* title_text)
     ui_room_card_config_t camera_config = {
         .room_id   = "cctv_main",
         .title     = "Backyard Camera",
-        .icon_text = LV_SYMBOL_EYE,
+        .icon_text = LV_SYMBOL_EYE_OPEN,
     };
 
     ui_room_card_t* camera_card     = ui_room_card_create(content, &camera_config);


### PR DESCRIPTION
## Summary
- update the CCTV room card configuration to use LV_SYMBOL_EYE_OPEN so the icon resolves in LVGL

## Testing
- clang-format -style=file -i custom/ui/pages/ui_page_cctv.c
- scripts/idf.py build *(fails: scripts/idf.py: line 3: IDF_PATH: unbound variable)*

------
https://chatgpt.com/codex/tasks/task_e_68cd15fa13f483248aab2dcd2a23838d