### PR TITLE
fix(ui): replace LV_ARRAY_SIZE loop bounds with sizeof expressions

### DIFF
--- a/custom/ui/pages/ui_page_cctv.c
+++ b/custom/ui/pages/ui_page_cctv.c
@@ -171,7 +171,7 @@ static lv_obj_t* ui_page_create_content(lv_obj_t* page, const char* title_text)
         {"drive", "Driveway", "Vehicle Detected", "Today · 11:58"},
     };
 
-    for (size_t i = 0; i < LV_ARRAY_SIZE(k_event_cards); i++)
+    for (size_t i = 0; i < (sizeof(k_event_cards) / sizeof(k_event_cards[0])); i++)
     {
         ui_room_card_config_t event_config = {
             .room_id   = k_event_cards[i].room_id,
@@ -221,7 +221,7 @@ static lv_obj_t* ui_page_create_content(lv_obj_t* page, const char* title_text)
         "Timeline ▾",
     };
 
-    for (size_t i = 0; i < LV_ARRAY_SIZE(k_actions); i++)
+    for (size_t i = 0; i < (sizeof(k_actions) / sizeof(k_actions[0])); i++)
     {
         lv_obj_t* action_btn = lv_btn_create(actions_row);
         lv_obj_remove_style_all(action_btn);

--- a/custom/ui/pages/ui_page_media.c
+++ b/custom/ui/pages/ui_page_media.c
@@ -141,7 +141,7 @@ lv_obj_t* ui_page_media_create(lv_obj_t* parent)
             lv_obj_clear_flag(transport_row, LV_OBJ_FLAG_SCROLLABLE);
 
             const char* button_labels[] = {"Prev", "Play/Pause", "Next"};
-            for (size_t i = 0; i < LV_ARRAY_SIZE(button_labels); i++)
+            for (size_t i = 0; i < (sizeof(button_labels) / sizeof(button_labels[0])); i++)
             {
                 lv_obj_t* control_btn = lv_btn_create(transport_row);
                 lv_obj_remove_style_all(control_btn);
@@ -214,7 +214,7 @@ lv_obj_t* ui_page_media_create(lv_obj_t* parent)
             lv_obj_clear_flag(scene_grid, LV_OBJ_FLAG_SCROLLABLE);
 
             const char* scene_labels[] = {"Morning", "Movie", "Night", "Party"};
-            for (size_t i = 0; i < LV_ARRAY_SIZE(scene_labels); i++)
+            for (size_t i = 0; i < (sizeof(scene_labels) / sizeof(scene_labels[0])); i++)
             {
                 lv_obj_t* scene_btn = lv_btn_create(scene_grid);
                 lv_obj_remove_style_all(scene_btn);


### PR DESCRIPTION
## Summary
- replace LV_ARRAY_SIZE loop bounds in the CCTV and Media pages with sizeof-based expressions for safer iteration limits

## Testing
- `idf.py build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd16020fd883249a616047a71c3019