### PR TITLE
fix: cache theme option count in settings page

### DIFF
--- a/custom/ui/pages/ui_page_settings.c
+++ b/custom/ui/pages/ui_page_settings.c
@@ -66,6 +66,8 @@ static const theme_option_t k_theme_options[] = {
     {"midnight", "Midnight"},
 };
 
+static const size_t kThemeOptionCount = sizeof(k_theme_options) / sizeof(k_theme_options[0]);
+
 static const char* k_theme_options_list = "System Default\nSolar\nMidnight";
 
 static const struct
@@ -550,7 +552,7 @@ static void theme_state_async_cb(void* param)
 
     if (ctx->theme_dropdown != NULL && payload->variant_id[0] != '\0')
     {
-        for (uint32_t i = 0; i < LV_ARRAY_SIZE(k_theme_options); i++)
+        for (uint32_t i = 0; i < kThemeOptionCount; i++)
         {
             if (strcmp(k_theme_options[i].id, payload->variant_id) == 0)
             {
@@ -678,7 +680,7 @@ static void theme_dropdown_cb(lv_event_t* event)
     if (ctx->actions_bound && ctx->actions.set_theme_variant != NULL)
     {
         uint16_t index = lv_dropdown_get_selected(lv_event_get_target(event));
-        if (index < LV_ARRAY_SIZE(k_theme_options))
+        if (index < kThemeOptionCount)
         {
             ctx->actions.set_theme_variant(k_theme_options[index].id, ctx->actions_user_data);
         }


### PR DESCRIPTION
## Summary
- add a reusable constant for the number of theme options in the settings page
- reuse the constant inside the theme state and dropdown callbacks

## Testing
- idf.py build *(fails: command not found; ESP-IDF environment is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd2565bdc08324ba43df887b06557f