### PR TITLE
fix(app): include settings controller header

### DIFF
--- a/app/apps/app_launcher/view/view.h
+++ b/app/apps/app_launcher/view/view.h
@@ -12,6 +12,8 @@
 #include <smooth_lvgl.h>
 #include <vector>
 
+#include "custom/integration/settings_controller.h"
+
 struct ui_root_t;
 
 namespace custom::integration {


### PR DESCRIPTION
## Summary
- include the SettingsController interface in the launcher view header so the build sees a complete type

## Testing
- clang-format -n -style=file app/apps/app_launcher/view/view.h
- idf.py build

------
https://chatgpt.com/codex/tasks/task_e_68cd3c79d3f4832499784e8e42bd05dc