### PR TITLE
fix(build): normalize settings includes

### DIFF
--- a/app/apps/app_launcher/view/view.cpp
+++ b/app/apps/app_launcher/view/view.cpp
@@ -4,16 +4,17 @@
  * SPDX-License-Identifier: MIT
  */
 #include "view.h"
-#include <lvgl.h>
-#include <hal/hal.h>
-#include <mooncake_log.h>
+
+#include <apps/utils/audio/audio.h>
 #include <assets/assets.h>
+#include <hal/hal.h>
+#include <lvgl.h>
+#include <mooncake_log.h>
 #include <smooth_lvgl.h>
 #include <smooth_ui_toolkit.h>
-#include <apps/utils/audio/audio.h>
 
-#include "custom/integration/settings_controller.h"
-#include "custom/ui/pages/ui_page_settings.h"
+#include "integration/settings_controller.h"
+#include "ui/pages/ui_page_settings.h"
 #include "ui/ui_root.h"
 
 using namespace launcher_view;
@@ -57,17 +58,20 @@ void LauncherView::init()
     _panels.push_back(std::make_unique<PanelMusic>());
     _panels.push_back(std::make_unique<PanelComMonitor>());
 
-    for (auto& panel : _panels) {
+    for (auto& panel : _panels)
+    {
         panel->init();
     }
 
-    if (_ui_root != nullptr) {
+    if (_ui_root != nullptr)
+    {
         _settings_controller.reset();
         ui_root_destroy(_ui_root);
         _ui_root = nullptr;
     }
     _ui_root = ui_root_create();
-    if (_ui_root != nullptr) {
+    if (_ui_root != nullptr)
+    {
         _settings_controller = std::make_unique<SettingsController>();
 
         ui_page_settings_actions_t actions{};
@@ -185,7 +189,8 @@ void LauncherView::update()
 {
     LvglLockGuard lock;
 
-    for (auto& panel : _panels) {
+    for (auto& panel : _panels)
+    {
         panel->update(_is_stacked);
     }
 }
@@ -193,7 +198,8 @@ void LauncherView::update()
 LauncherView::~LauncherView()
 {
     _settings_controller.reset();
-    if (_ui_root != nullptr) {
+    if (_ui_root != nullptr)
+    {
         ui_root_destroy(_ui_root);
         _ui_root = nullptr;
     }

--- a/app/apps/app_launcher/view/view.h
+++ b/app/apps/app_launcher/view/view.h
@@ -4,311 +4,326 @@
  * SPDX-License-Identifier: MIT
  */
 #pragma once
-#include <cstdint>
-#include <memory>
-#include <lvgl.h>
 #include <apps/utils/ui/window.h>
-#include <smooth_ui_toolkit.h>
+#include <cstdint>
+#include <lvgl.h>
+#include <memory>
 #include <smooth_lvgl.h>
+#include <smooth_ui_toolkit.h>
 #include <vector>
-
-#include "custom/integration/settings_controller.h"
 
 struct ui_root_t;
 
-namespace custom::integration {
-class SettingsController;
+namespace custom::integration
+{
+    class SettingsController;
 }
 
-namespace launcher_view {
+namespace launcher_view
+{
 
-/**
- * @brief
- *
- */
-class PanelBase {
-public:
-    virtual ~PanelBase()
+    /**
+     * @brief
+     *
+     */
+    class PanelBase
     {
-    }
+    public:
+        virtual ~PanelBase() {}
 
-    virtual void init()                 = 0;
-    virtual void update(bool isStacked) = 0;
-};
+        virtual void init()                 = 0;
+        virtual void update(bool isStacked) = 0;
+    };
 
-/**
- * @brief
- *
- */
-class PanelRtc : public PanelBase {
-public:
-    void init() override;
-    void update(bool isStacked) override;
+    /**
+     * @brief
+     *
+     */
+    class PanelRtc : public PanelBase
+    {
+    public:
+        void init() override;
+        void update(bool isStacked) override;
 
-private:
-    uint32_t _time_count = 0;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label> _label_time;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label> _label_date;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_rtc_setting;
-    std::unique_ptr<ui::Window> _window;
-};
+    private:
+        uint32_t                                                _time_count = 0;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label>     _label_time;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label>     _label_date;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_rtc_setting;
+        std::unique_ptr<ui::Window>                             _window;
+    };
 
-/**
- * @brief
- *
- */
-class PanelLcdBacklight : public PanelBase {
-public:
-    void init() override;
-    void update(bool isStacked) override;
+    /**
+     * @brief
+     *
+     */
+    class PanelLcdBacklight : public PanelBase
+    {
+    public:
+        void init() override;
+        void update(bool isStacked) override;
 
-private:
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label> _label_brightness;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_up;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_down;
-    smooth_ui_toolkit::AnimateValue _label_y_anim;
-};
+    private:
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label>     _label_brightness;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_up;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_down;
+        smooth_ui_toolkit::AnimateValue                         _label_y_anim;
+    };
 
-/**
- * @brief
- *
- */
-class PanelSpeakerVolume : public PanelBase {
-public:
-    void init() override;
-    void update(bool isStacked) override;
+    /**
+     * @brief
+     *
+     */
+    class PanelSpeakerVolume : public PanelBase
+    {
+    public:
+        void init() override;
+        void update(bool isStacked) override;
 
-private:
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label> _label_volume;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_up;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_down;
-    smooth_ui_toolkit::AnimateValue _label_y_anim;
-};
+    private:
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label>     _label_volume;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_up;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_down;
+        smooth_ui_toolkit::AnimateValue                         _label_y_anim;
+    };
 
-/**
- * @brief
- *
- */
-class PanelPowerMonitor : public PanelBase {
-public:
-    void init() override;
-    void update(bool isStacked) override;
+    /**
+     * @brief
+     *
+     */
+    class PanelPowerMonitor : public PanelBase
+    {
+    public:
+        void init() override;
+        void update(bool isStacked) override;
 
-private:
-    uint32_t _pm_data_update_time_count  = 0;
-    uint32_t _cpu_temp_update_time_count = 0;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label> _label_voltage;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label> _label_current;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label> _label_cpu_temp;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image> _img_chg_arrow_up;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image> _img_chg_arrow_down;
-};
+    private:
+        uint32_t                                            _pm_data_update_time_count  = 0;
+        uint32_t                                            _cpu_temp_update_time_count = 0;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label> _label_voltage;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label> _label_current;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label> _label_cpu_temp;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image> _img_chg_arrow_up;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image> _img_chg_arrow_down;
+    };
 
-/**
- * @brief
- *
- */
-class PanelImu : public PanelBase {
-public:
-    void init() override;
-    void update(bool isStacked) override;
+    /**
+     * @brief
+     *
+     */
+    class PanelImu : public PanelBase
+    {
+    public:
+        void init() override;
+        void update(bool isStacked) override;
 
-private:
-    uint32_t _time_count = 0;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label> _label_accel_x;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label> _label_accel_y;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label> _label_accel_z;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _accel_dot;
-    smooth_ui_toolkit::AnimateValue _anim_x;
-    smooth_ui_toolkit::AnimateValue _anim_y;
-    smooth_ui_toolkit::AnimateValue _anim_size;
-};
+    private:
+        uint32_t                                                _time_count = 0;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label>     _label_accel_x;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label>     _label_accel_y;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Label>     _label_accel_z;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _accel_dot;
+        smooth_ui_toolkit::AnimateValue                         _anim_x;
+        smooth_ui_toolkit::AnimateValue                         _anim_y;
+        smooth_ui_toolkit::AnimateValue                         _anim_size;
+    };
 
-/**
- * @brief
- *
- */
-class PanelSwitches : public PanelBase {
-public:
-    void init() override;
-    void update(bool isStacked) override;
+    /**
+     * @brief
+     *
+     */
+    class PanelSwitches : public PanelBase
+    {
+    public:
+        void init() override;
+        void update(bool isStacked) override;
 
-private:
-    uint32_t _time_count = 0;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image> _img_charge_en_sw;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image> _img_charge_qc_en_sw;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image> _img_ext_5v_en_sw;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image> _img_usba_5v_en_sw;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image> _img_ext_antenna_en_sw;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_charge_en_sw;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_charge_qc_en_sw;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_ext_5v_en_sw;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_usba_5v_en_sw;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_ext_antenna_en_sw;
+    private:
+        uint32_t                                                _time_count = 0;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image>     _img_charge_en_sw;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image>     _img_charge_qc_en_sw;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image>     _img_ext_5v_en_sw;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image>     _img_usba_5v_en_sw;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image>     _img_ext_antenna_en_sw;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_charge_en_sw;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_charge_qc_en_sw;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_ext_5v_en_sw;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_usba_5v_en_sw;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_ext_antenna_en_sw;
 
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image> _img_usb_c_detect;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image> _img_usb_a_detect;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image> _img_hp_detect;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image> _img_usb_c_detect;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image> _img_usb_a_detect;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image> _img_hp_detect;
 
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_ap_msg;
-    std::unique_ptr<ui::Window> _window;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_ap_msg;
+        std::unique_ptr<ui::Window>                             _window;
 
-    bool _last_usb_c_detect = false;
-    bool _last_usb_a_detect = false;
-    bool _last_hp_detect    = false;
+        bool _last_usb_c_detect = false;
+        bool _last_usb_a_detect = false;
+        bool _last_hp_detect    = false;
 
-    void update_images();
-    void update_detect_images();
-    void play_sfx(bool isPlugedIn);
-};
+        void update_images();
+        void update_detect_images();
+        void play_sfx(bool isPlugedIn);
+    };
 
-/**
- * @brief
- *
- */
-class PanelPower : public PanelBase {
-public:
-    void init() override;
-    void update(bool isStacked) override;
+    /**
+     * @brief
+     *
+     */
+    class PanelPower : public PanelBase
+    {
+    public:
+        void init() override;
+        void update(bool isStacked) override;
 
-private:
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_power_off;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_sleep_touch_wakeup;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_sleep_shake_wakeup;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_sleep_rtc_wakeup;
-    std::unique_ptr<ui::Window> _window;
-};
+    private:
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_power_off;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_sleep_touch_wakeup;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_sleep_shake_wakeup;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_sleep_rtc_wakeup;
+        std::unique_ptr<ui::Window>                             _window;
+    };
 
-/**
- * @brief
- *
- */
-class PanelCamera : public PanelBase {
-public:
-    void init() override;
-    void update(bool isStacked) override;
+    /**
+     * @brief
+     *
+     */
+    class PanelCamera : public PanelBase
+    {
+    public:
+        void init() override;
+        void update(bool isStacked) override;
 
-private:
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_camera;
-    std::unique_ptr<ui::Window> _window;
-};
+    private:
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_camera;
+        std::unique_ptr<ui::Window>                             _window;
+    };
 
-/**
- * @brief
- *
- */
-class PanelDualMic : public PanelBase {
-public:
-    void init() override;
-    void update(bool isStacked) override;
+    /**
+     * @brief
+     *
+     */
+    class PanelDualMic : public PanelBase
+    {
+    public:
+        void init() override;
+        void update(bool isStacked) override;
 
-private:
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_mic_test;
-    std::unique_ptr<ui::Window> _window;
-};
+    private:
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_mic_test;
+        std::unique_ptr<ui::Window>                             _window;
+    };
 
-/**
- * @brief
- *
- */
-class PanelHeadphone : public PanelBase {
-public:
-    void init() override;
-    void update(bool isStacked) override;
+    /**
+     * @brief
+     *
+     */
+    class PanelHeadphone : public PanelBase
+    {
+    public:
+        void init() override;
+        void update(bool isStacked) override;
 
-private:
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_headphone_test;
-    std::unique_ptr<ui::Window> _window;
-};
+    private:
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_headphone_test;
+        std::unique_ptr<ui::Window>                             _window;
+    };
 
-/**
- * @brief
- *
- */
-class PanelSdCard : public PanelBase {
-public:
-    void init() override;
-    void update(bool isStacked) override;
+    /**
+     * @brief
+     *
+     */
+    class PanelSdCard : public PanelBase
+    {
+    public:
+        void init() override;
+        void update(bool isStacked) override;
 
-private:
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_sd_card_scan;
-    std::unique_ptr<ui::Window> _window;
-};
+    private:
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_sd_card_scan;
+        std::unique_ptr<ui::Window>                             _window;
+    };
 
-/**
- * @brief
- *
- */
-class PanelI2cScan : public PanelBase {
-public:
-    void init() override;
-    void update(bool isStacked) override;
+    /**
+     * @brief
+     *
+     */
+    class PanelI2cScan : public PanelBase
+    {
+    public:
+        void init() override;
+        void update(bool isStacked) override;
 
-private:
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_i2c_scan;
-    std::unique_ptr<ui::Window> _window;
-};
+    private:
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_i2c_scan;
+        std::unique_ptr<ui::Window>                             _window;
+    };
 
-/**
- * @brief
- *
- */
-class PanelGpioTest : public PanelBase {
-public:
-    void init() override;
-    void update(bool isStacked) override;
+    /**
+     * @brief
+     *
+     */
+    class PanelGpioTest : public PanelBase
+    {
+    public:
+        void init() override;
+        void update(bool isStacked) override;
 
-private:
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_gpio_test;
-    std::unique_ptr<ui::Window> _window;
-};
+    private:
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_gpio_test;
+        std::unique_ptr<ui::Window>                             _window;
+    };
 
-/**
- * @brief
- *
- */
-class PanelMusic : public PanelBase {
-public:
-    void init() override;
-    void update(bool isStacked) override;
+    /**
+     * @brief
+     *
+     */
+    class PanelMusic : public PanelBase
+    {
+    public:
+        void init() override;
+        void update(bool isStacked) override;
 
-private:
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_music_test;
-    std::unique_ptr<ui::Window> _window;
-};
+    private:
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_music_test;
+        std::unique_ptr<ui::Window>                             _window;
+    };
 
-/**
- * @brief
- *
- */
-class PanelComMonitor : public PanelBase {
-public:
-    void init() override;
-    void update(bool isStacked) override;
+    /**
+     * @brief
+     *
+     */
+    class PanelComMonitor : public PanelBase
+    {
+    public:
+        void init() override;
+        void update(bool isStacked) override;
 
-private:
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_com_monitor;
-    std::unique_ptr<ui::Window> _window;
-};
+    private:
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Container> _btn_com_monitor;
+        std::unique_ptr<ui::Window>                             _window;
+    };
 
-/**
- * @brief
- *
- */
-class LauncherView {
-public:
-    void init();
-    void update();
-    ~LauncherView();
+    /**
+     * @brief
+     *
+     */
+    class LauncherView
+    {
+    public:
+        void init();
+        void update();
+        ~LauncherView();
 
-private:
-    bool _is_stacked = false;
-    std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image> _img_bg;
-    std::vector<std::unique_ptr<PanelBase>> _panels;
-    ui_root_t *_ui_root = nullptr;
-    std::unique_ptr<custom::integration::SettingsController> _settings_controller;
+    private:
+        bool                                                     _is_stacked = false;
+        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image>      _img_bg;
+        std::vector<std::unique_ptr<PanelBase>>                  _panels;
+        ui_root_t*                                               _ui_root = nullptr;
+        std::unique_ptr<custom::integration::SettingsController> _settings_controller;
 
-    void update_anim();
-};
+        void update_anim();
+    };
 
 }  // namespace launcher_view

--- a/custom/integration/settings_controller.cpp
+++ b/custom/integration/settings_controller.cpp
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-#include "custom/integration/settings_controller.h"
+#include "integration/settings_controller.h"
 
 #include <algorithm>
 #include <chrono>
@@ -22,10 +22,10 @@
 #include <vector>
 
 #include "core/app_trace.h"
-#include "custom/ui/pages/ui_page_settings.h"
 #include "hal/hal.h"
 #include "settings_core/app_cfg.h"
 #include "settings_ui/settings_ui.h"
+#include "ui/pages/ui_page_settings.h"
 
 #if defined(ESP_PLATFORM)
 #    include "backup_server/backup_format.h"


### PR DESCRIPTION
## Summary
- stop including the settings controller header from the custom/ path in the launcher view header
- include integration/settings_controller.h and ui/pages/ui_page_settings.h in the launcher view implementation
- update settings_controller.cpp to include the integration header and the relocated settings page header

## Testing
- clang-format app/apps/app_launcher/view/view.cpp app/apps/app_launcher/view/view.h custom/integration/settings_controller.cpp
- idf.py build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4335390c8324a99a742dbc3f4758