### PR TITLE
fix: include settings controller header in launcher view

### DIFF
--- a/app/apps/app_launcher/view/view.h
+++ b/app/apps/app_launcher/view/view.h
@@ -12,12 +12,9 @@
 #include <smooth_ui_toolkit.h>
 #include <vector>
 
-struct ui_root_t;
+#include "integration/settings_controller.h"
 
-namespace custom::integration
-{
-    class SettingsController;
-}
+struct ui_root_t;
 
 namespace launcher_view
 {


### PR DESCRIPTION
## Summary
- include the settings controller header in the launcher view interface so the unique_ptr has a complete type

## Testing
- idf.py build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd482ae13483249e3672454f59cae6