### PR TITLE
feat: integrate CCTV state model and controller

### DIFF
--- a/app/apps/app_launcher/view/view.cpp
+++ b/app/apps/app_launcher/view/view.cpp
@@ -13,6 +13,7 @@
 #include <smooth_lvgl.h>
 #include <smooth_ui_toolkit.h>
 
+#include "integration/cctv_controller.h"
 #include "integration/settings_controller.h"
 #include "ui/pages/ui_page_settings.h"
 #include "ui/ui_root.h"
@@ -65,6 +66,7 @@ void LauncherView::init()
 
     if (_ui_root != nullptr)
     {
+        _cctv_controller.reset();
         _settings_controller.reset();
         ui_root_destroy(_ui_root);
         _ui_root = nullptr;
@@ -73,6 +75,7 @@ void LauncherView::init()
     if (_ui_root != nullptr)
     {
         _settings_controller = std::make_unique<SettingsController>();
+        _cctv_controller     = std::make_unique<CctvController>();
 
         ui_page_settings_actions_t actions{};
         actions.run_connection_test = [](const char* tester_id, void* user_data)
@@ -182,6 +185,10 @@ void LauncherView::init()
 
         ui_page_settings_set_actions(&actions, _settings_controller.get());
         _settings_controller->PublishInitialState();
+        if (_cctv_controller != nullptr)
+        {
+            _cctv_controller->PublishInitialState();
+        }
     }
 }
 
@@ -197,6 +204,7 @@ void LauncherView::update()
 
 LauncherView::~LauncherView()
 {
+    _cctv_controller.reset();
     _settings_controller.reset();
     if (_ui_root != nullptr)
     {

--- a/app/apps/app_launcher/view/view.h
+++ b/app/apps/app_launcher/view/view.h
@@ -14,6 +14,11 @@
 
 #include "integration/settings_controller.h"
 
+namespace custom::integration
+{
+    class CctvController;
+}
+
 struct ui_root_t;
 
 namespace launcher_view
@@ -319,6 +324,7 @@ namespace launcher_view
         std::vector<std::unique_ptr<PanelBase>>                  _panels;
         ui_root_t*                                               _ui_root = nullptr;
         std::unique_ptr<custom::integration::SettingsController> _settings_controller;
+        std::unique_ptr<custom::integration::CctvController>     _cctv_controller;
 
         void update_anim();
     };

--- a/custom/integration/cctv_controller.cpp
+++ b/custom/integration/cctv_controller.cpp
@@ -1,0 +1,246 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include "integration/cctv_controller.h"
+
+#include <algorithm>
+#include <array>
+
+#include "core/app_trace.h"
+
+namespace custom::integration
+{
+
+    namespace
+    {
+
+        constexpr const char* kTag = "cctv-controller";
+
+        constexpr std::array<const char*, 3> kQualityOptions = {
+            "1080p60",
+            "720p30",
+            "360p15",
+        };
+
+        constexpr ui_page_cctv_camera_t kCameras[] = {
+            {
+                .camera_id       = "front_porch",
+                .name            = "Front Porch",
+                .status          = "Streaming · 1080p60",
+                .stream_url      = "rtsp://frigate/front_porch/stream",
+                .snapshot_url    = "https://frigate.local/api/front_porch.jpg",
+                .audio_supported = true,
+            },
+            {
+                .camera_id       = "garage",
+                .name            = "Garage Bay",
+                .status          = "Idle · Door closed",
+                .stream_url      = "rtsp://frigate/garage/stream",
+                .snapshot_url    = "https://frigate.local/api/garage.jpg",
+                .audio_supported = false,
+            },
+            {
+                .camera_id       = "backyard",
+                .name            = "Backyard",
+                .status          = "Streaming · 1440p30",
+                .stream_url      = "rtsp://frigate/backyard/stream",
+                .snapshot_url    = "https://frigate.local/api/backyard.jpg",
+                .audio_supported = true,
+            },
+        };
+
+        constexpr ui_page_cctv_event_t kEvents[] = {
+            {
+                .event_id     = "evt_front_1742",
+                .camera_id    = "front_porch",
+                .title        = "Front Porch",
+                .description  = "Person detected · 2m ago",
+                .timestamp    = "Today · 17:42",
+                .clip_url     = "https://frigate.local/api/front_porch/event/evt_front_1742.mp4",
+                .snapshot_url = "https://frigate.local/api/front_porch/event/evt_front_1742.jpg",
+            },
+            {
+                .event_id     = "evt_drive_1737",
+                .camera_id    = "garage",
+                .title        = "Driveway",
+                .description  = "Vehicle detected",
+                .timestamp    = "Today · 17:37",
+                .clip_url     = "https://frigate.local/api/garage/event/evt_drive_1737.mp4",
+                .snapshot_url = "https://frigate.local/api/garage/event/evt_drive_1737.jpg",
+            },
+            {
+                .event_id     = "evt_gate_1715",
+                .camera_id    = "backyard",
+                .title        = "Backyard Gate",
+                .description  = "Package drop-off",
+                .timestamp    = "Today · 17:15",
+                .clip_url     = "https://frigate.local/api/backyard/event/evt_gate_1715.mp4",
+                .snapshot_url = "https://frigate.local/api/backyard/event/evt_gate_1715.jpg",
+            },
+        };
+
+        constexpr std::size_t CameraCount = sizeof(kCameras) / sizeof(kCameras[0]);
+        constexpr std::size_t EventCount  = sizeof(kEvents) / sizeof(kEvents[0]);
+
+    }  // namespace
+
+    CctvController::CctvController()
+    {
+        page_ = ui_page_cctv_get_obj();
+        if (page_ != nullptr)
+        {
+            lv_obj_add_event_cb(page_, PageEventCb, UI_PAGE_CCTV_EVENT_ACTION, this);
+            lv_obj_add_event_cb(page_, PageEventCb, UI_PAGE_CCTV_EVENT_OPEN_CLIP, this);
+        }
+    }
+
+    CctvController::~CctvController()
+    {
+        if (page_ != nullptr)
+        {
+            lv_obj_remove_event_cb_with_user_data(page_, PageEventCb, this);
+        }
+    }
+
+    void CctvController::PublishInitialState()
+    {
+        PushState();
+    }
+
+    void CctvController::PageEventCb(lv_event_t* event)
+    {
+        if (event == nullptr)
+        {
+            return;
+        }
+
+        auto* controller = static_cast<CctvController*>(lv_event_get_user_data(event));
+        if (controller == nullptr)
+        {
+            return;
+        }
+
+        lv_event_code_t code = lv_event_get_code(event);
+
+        if (code == UI_PAGE_CCTV_EVENT_ACTION)
+        {
+            const auto* action =
+                static_cast<const ui_page_cctv_action_event_t*>(lv_event_get_param(event));
+            if (action != nullptr)
+            {
+                controller->HandleAction(*action);
+            }
+        }
+        +else if (code == UI_PAGE_CCTV_EVENT_OPEN_CLIP) +
+        {
+            +const auto* clip =
+                static_cast<const ui_page_cctv_clip_event_t*>(lv_event_get_param(event));
+            +if (clip != nullptr) +
+            {
+                +controller->HandleClipRequest(*clip);
+                +
+            }
+            +
+        }
+    }
+
+    void CctvController::HandleAction(const ui_page_cctv_action_event_t& action)
+    {
+        if (CameraCount == 0)
+        {
+            return;
+        }
+
+        switch (action.action)
+        {
+            case UI_PAGE_CCTV_ACTION_PREVIOUS:
+                if (CameraCount > 0)
+                {
+                    if (active_index_ == 0)
+                    {
+                        active_index_ = CameraCount - 1;
+                    }
+                    else
+                    {
+                        active_index_--;
+                    }
+                    PushState();
+                }
+                break;
+
+            case UI_PAGE_CCTV_ACTION_NEXT:
+                if (CameraCount > 0)
+                {
+                    active_index_ = (active_index_ + 1) % CameraCount;
+                    PushState();
+                }
+                break;
+
+            case UI_PAGE_CCTV_ACTION_QUALITY:
+                quality_index_ = (quality_index_ + 1) % kQualityOptions.size();
+                PushState();
+                break;
+
+            case UI_PAGE_CCTV_ACTION_TOGGLE_MUTE:
+                muted_ = !muted_;
+                PushState();
+                break;
+
+            case UI_PAGE_CCTV_ACTION_OPEN_GATE:
+                APP_TRACEI(kTag,
+                           "Requested gate open for camera %s",
+                           action.camera_id != nullptr ? action.camera_id : "(none)");
+                break;
+
+            case UI_PAGE_CCTV_ACTION_TALK:
+                APP_TRACEI(kTag,
+                           "Initiating talkback on %s",
+                           action.camera_id != nullptr ? action.camera_id : "(none)");
+                break;
+
+            case UI_PAGE_CCTV_ACTION_SNAPSHOT:
+                APP_TRACEI(kTag,
+                           "Snapshot requested for %s",
+                           action.camera_id != nullptr ? action.camera_id : "(none)");
+                break;
+
+            case UI_PAGE_CCTV_ACTION_TIMELINE:
+                APP_TRACEI(kTag, "Timeline requested (events=%u)", (unsigned int)EventCount);
+                break;
+        }
+    }
+
+    void CctvController::HandleClipRequest(const ui_page_cctv_clip_event_t& clip)
+    {
+        if (clip.event == nullptr)
+        {
+            return;
+        }
+
+        const char* clip_id = clip.event->event_id != nullptr ? clip.event->event_id : "(unknown)";
+        APP_TRACEI(kTag, "Open clip %s", clip_id);
+    }
+
+    void CctvController::PushState()
+    {
+        if (page_ == nullptr)
+        {
+            return;
+        }
+
+        ui_page_cctv_state_t state = {
+            .cameras       = kCameras,
+            .camera_count  = CameraCount,
+            .active_index  = std::min(active_index_, CameraCount > 0 ? CameraCount - 1 : 0),
+            .events        = kEvents,
+            .event_count   = EventCount,
+            .quality_label = kQualityOptions[quality_index_],
+            .muted         = muted_,
+        };
+
+        ui_page_cctv_set_state(&state);
+    }
+
+}  // namespace custom::integration

--- a/custom/integration/cctv_controller.h
+++ b/custom/integration/cctv_controller.h
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: 2025 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#pragma once
+
+#include <cstddef>
+
+#ifdef __has_include
+#    if __has_include("lvgl.h")
+#        ifndef LV_LVGL_H_INCLUDE_SIMPLE
+#            define LV_LVGL_H_INCLUDE_SIMPLE
+#        endif
+#    endif
+#endif
+
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#    include "lvgl.h"
+#else
+#    include "lvgl/lvgl.h"
+#endif
+
+#include "ui/pages/ui_page_cctv.h"
+
+namespace custom::integration
+{
+
+    class CctvController
+    {
+    public:
+        CctvController();
+        ~CctvController();
+
+        CctvController(const CctvController&)            = delete;
+        CctvController& operator=(const CctvController&) = delete;
+
+        void PublishInitialState();
+
+    private:
+        static void PageEventCb(lv_event_t* event);
+
+        void HandleAction(const ui_page_cctv_action_event_t& action);
+        void HandleClipRequest(const ui_page_cctv_clip_event_t& clip);
+        void PushState();
+
+        lv_obj_t*   page_          = nullptr;
+        std::size_t active_index_  = 0;
+        std::size_t quality_index_ = 0;
+        bool        muted_         = false;
+    };
+
+}  // namespace custom::integration

--- a/custom/ui/pages/ui_page_cctv.c
+++ b/custom/ui/pages/ui_page_cctv.c
@@ -5,36 +5,603 @@
  */
 #include "ui_page_cctv.h"
 
+#include <string.h>
+
 #include "../ui_theme.h"
 #include "../ui_wallpaper.h"
 #include "../widgets/ui_room_card.h"
 
-static void ui_page_cctv_delete_cb(lv_event_t* event)
+typedef struct
 {
-    ui_wallpaper_t* wallpaper = (ui_wallpaper_t*)lv_event_get_user_data(event);
-    ui_wallpaper_detach(wallpaper);
+    lv_obj_t*            card_obj;
+    ui_page_cctv_event_t event;
+} ui_page_cctv_event_slot_t;
+
+typedef struct
+{
+    lv_obj_t*       page;
+    lv_obj_t*       content;
+    lv_obj_t*       toolbar;
+    lv_obj_t*       prev_btn;
+    lv_obj_t*       next_btn;
+    lv_obj_t*       quality_btn;
+    lv_obj_t*       mute_btn;
+    lv_obj_t*       camera_index_label;
+    lv_obj_t*       quality_label;
+    lv_obj_t*       mute_label;
+    ui_room_card_t* camera_card;
+    lv_obj_t*       camera_title_label;
+    lv_obj_t*       camera_specs_label;
+    lv_obj_t*       video_container;
+    lv_obj_t*       stream_label;
+    lv_obj_t*       events_row;
+    lv_obj_t*       actions_row;
+    lv_obj_t*       open_gate_button;
+    lv_obj_t*       talk_button;
+    lv_obj_t*       snapshot_button;
+    lv_obj_t*       timeline_button;
+    ui_wallpaper_t* wallpaper;
+
+    size_t camera_count;
+    size_t active_index;
+    bool   muted;
+    bool   audio_supported;
+
+    char* active_camera_id;
+    char* active_stream_url;
+    char* quality_label_text;
+
+    ui_page_cctv_event_slot_t* event_slots;
+    size_t                     event_count;
+} ui_page_cctv_ctx_t;
+
+static ui_page_cctv_ctx_t* s_ctx = NULL;
+
+static char* duplicate_string(const char* source)
+{
+    if (source == NULL)
+    {
+        return NULL;
+    }
+
+    size_t length = strlen(source);
+    char*  copy   = (char*)lv_malloc(length + 1);
+    if (copy == NULL)
+    {
+        return NULL;
+    }
+
+    memcpy(copy, source, length);
+    copy[length] = '\0';
+    return copy;
 }
 
-static lv_obj_t* ui_page_create_content(lv_obj_t* page, const char* title_text)
+static void replace_string(char** destination, const char* value)
 {
-    lv_obj_t* content = lv_obj_create(page);
-    lv_obj_remove_style_all(content);
-    lv_obj_set_size(content, LV_PCT(100), LV_PCT(100));
-    lv_obj_set_style_bg_opa(content, LV_OPA_TRANSP, LV_PART_MAIN);
-    lv_obj_set_style_pad_left(content, 192, LV_PART_MAIN);
-    lv_obj_set_style_pad_right(content, 48, LV_PART_MAIN);
-    lv_obj_set_style_pad_top(content, 48, LV_PART_MAIN);
-    lv_obj_set_style_pad_bottom(content, 48, LV_PART_MAIN);
-    lv_obj_set_style_pad_gap(content, 32, LV_PART_MAIN);
-    lv_obj_set_flex_flow(content, LV_FLEX_FLOW_COLUMN);
-    lv_obj_set_flex_align(content, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+    if (destination == NULL)
+    {
+        return;
+    }
 
-    lv_obj_t* title = lv_label_create(content);
-    lv_label_set_text(title, title_text);
-    lv_obj_set_style_text_font(title, &lv_font_montserrat_32, LV_PART_MAIN);
-    lv_obj_set_style_text_color(title, ui_theme_color_on_surface(), LV_PART_MAIN);
+    if (*destination != NULL)
+    {
+        lv_free(*destination);
+        *destination = NULL;
+    }
 
-    lv_obj_t* toolbar = lv_obj_create(content);
+    if (value != NULL)
+    {
+        *destination = duplicate_string(value);
+    }
+}
+
+static void free_event_slot(ui_page_cctv_event_slot_t* slot)
+{
+    if (slot == NULL)
+    {
+        return;
+    }
+
+    if (slot->event.event_id != NULL)
+    {
+        lv_free((void*)slot->event.event_id);
+        slot->event.event_id = NULL;
+    }
+    if (slot->event.camera_id != NULL)
+    {
+        lv_free((void*)slot->event.camera_id);
+        slot->event.camera_id = NULL;
+    }
+    if (slot->event.title != NULL)
+    {
+        lv_free((void*)slot->event.title);
+        slot->event.title = NULL;
+    }
+    if (slot->event.description != NULL)
+    {
+        lv_free((void*)slot->event.description);
+        slot->event.description = NULL;
+    }
+    if (slot->event.timestamp != NULL)
+    {
+        lv_free((void*)slot->event.timestamp);
+        slot->event.timestamp = NULL;
+    }
+    if (slot->event.clip_url != NULL)
+    {
+        lv_free((void*)slot->event.clip_url);
+        slot->event.clip_url = NULL;
+    }
+    if (slot->event.snapshot_url != NULL)
+    {
+        lv_free((void*)slot->event.snapshot_url);
+        slot->event.snapshot_url = NULL;
+    }
+    slot->card_obj = NULL;
+}
+
+static void clear_event_slots(ui_page_cctv_ctx_t* ctx)
+{
+    if (ctx == NULL || ctx->event_slots == NULL)
+    {
+        return;
+    }
+
+    for (size_t i = 0; i < ctx->event_count; i++)
+    {
+        free_event_slot(&ctx->event_slots[i]);
+    }
+
+    lv_free(ctx->event_slots);
+    ctx->event_slots = NULL;
+    ctx->event_count = 0;
+}
+
+static void update_toolbar(ui_page_cctv_ctx_t* ctx)
+{
+    if (ctx == NULL)
+    {
+        return;
+    }
+
+    bool has_camera = (ctx->camera_count > 0);
+
+    if (ctx->camera_index_label != NULL)
+    {
+        if (has_camera)
+        {
+            lv_label_set_text_fmt(ctx->camera_index_label,
+                                  "Camera %u of %u",
+                                  (unsigned int)(ctx->active_index + 1),
+                                  (unsigned int)ctx->camera_count);
+        }
+        else
+        {
+            lv_label_set_text(ctx->camera_index_label, "No cameras");
+        }
+    }
+
+    if (ctx->prev_btn != NULL)
+    {
+        if (ctx->camera_count > 1)
+        {
+            lv_obj_clear_state(ctx->prev_btn, LV_STATE_DISABLED);
+        }
+        else
+        {
+            lv_obj_add_state(ctx->prev_btn, LV_STATE_DISABLED);
+        }
+    }
+
+    if (ctx->next_btn != NULL)
+    {
+        if (ctx->camera_count > 1)
+        {
+            lv_obj_clear_state(ctx->next_btn, LV_STATE_DISABLED);
+        }
+        else
+        {
+            lv_obj_add_state(ctx->next_btn, LV_STATE_DISABLED);
+        }
+    }
+
+    const char* quality_label = NULL;
+    if (ctx->quality_label_text != NULL && ctx->quality_label_text[0] != '\0')
+    {
+        quality_label = ctx->quality_label_text;
+    }
+
+    if (ctx->quality_label != NULL)
+    {
+        if (quality_label != NULL)
+        {
+            lv_label_set_text_fmt(ctx->quality_label, "%s ▾", quality_label);
+        }
+        else
+        {
+            lv_label_set_text(ctx->quality_label, "Quality ▾");
+        }
+    }
+
+    if (ctx->quality_btn != NULL)
+    {
+        if (has_camera)
+        {
+            lv_obj_clear_state(ctx->quality_btn, LV_STATE_DISABLED);
+        }
+        else
+        {
+            lv_obj_add_state(ctx->quality_btn, LV_STATE_DISABLED);
+        }
+    }
+
+    if (ctx->mute_btn != NULL)
+    {
+        if (has_camera && ctx->audio_supported)
+        {
+            lv_obj_clear_state(ctx->mute_btn, LV_STATE_DISABLED);
+        }
+        else
+        {
+            lv_obj_add_state(ctx->mute_btn, LV_STATE_DISABLED);
+        }
+    }
+
+    if (ctx->mute_label != NULL)
+    {
+        if (has_camera && ctx->audio_supported)
+        {
+            const char* mute_text = ctx->muted ? LV_SYMBOL_MUTE " Unmute" : LV_SYMBOL_AUDIO " Mute";
+            lv_label_set_text(ctx->mute_label, mute_text);
+        }
+        else
+        {
+            lv_label_set_text(ctx->mute_label, LV_SYMBOL_AUDIO " Mute");
+        }
+    }
+}
+
+static void update_camera_card(ui_page_cctv_ctx_t* ctx, const ui_page_cctv_camera_t* camera)
+{
+    if (ctx == NULL || ctx->camera_card == NULL)
+    {
+        return;
+    }
+
+    if (ctx->camera_title_label != NULL)
+    {
+        if (camera != NULL && camera->name != NULL)
+        {
+            lv_label_set_text(ctx->camera_title_label, camera->name);
+        }
+        else
+        {
+            lv_label_set_text(ctx->camera_title_label, "Camera");
+        }
+    }
+
+    if (ctx->camera_specs_label != NULL)
+    {
+        if (camera != NULL && camera->status != NULL)
+        {
+            lv_label_set_text(ctx->camera_specs_label, camera->status);
+        }
+        else
+        {
+            lv_label_set_text(ctx->camera_specs_label, "Select a camera to view live feed.");
+        }
+    }
+
+    if (ctx->stream_label != NULL)
+    {
+        if (camera != NULL)
+        {
+            if (camera->stream_url != NULL && camera->stream_url[0] != '\0')
+            {
+                lv_label_set_text_fmt(ctx->stream_label, "Live stream: %s", camera->stream_url);
+            }
+            else if (camera->snapshot_url != NULL && camera->snapshot_url[0] != '\0')
+            {
+                lv_label_set_text_fmt(
+                    ctx->stream_label, "Snapshot fallback: %s", camera->snapshot_url);
+            }
+            else
+            {
+                lv_label_set_text(ctx->stream_label, "Live stream unavailable");
+            }
+        }
+        else
+        {
+            lv_label_set_text(ctx->stream_label, "Add cameras in Home Assistant to view feeds.");
+        }
+    }
+}
+
+static void event_card_clicked_cb(lv_event_t* event)
+{
+    if (event == NULL)
+    {
+        return;
+    }
+
+    ui_page_cctv_ctx_t* ctx = (ui_page_cctv_ctx_t*)lv_event_get_user_data(event);
+    if (ctx == NULL || ctx->page == NULL || ctx->event_slots == NULL)
+    {
+        return;
+    }
+
+    lv_obj_t* target = lv_event_get_target(event);
+
+    for (size_t i = 0; i < ctx->event_count; i++)
+    {
+        if (ctx->event_slots[i].card_obj == target)
+        {
+            ui_page_cctv_clip_event_t clip = {
+                .event = &ctx->event_slots[i].event,
+                .index = i,
+            };
+            lv_event_send(ctx->page, UI_PAGE_CCTV_EVENT_OPEN_CLIP, &clip);
+            break;
+        }
+    }
+}
+
+static void
+update_events(ui_page_cctv_ctx_t* ctx, const ui_page_cctv_event_t* events, size_t event_count)
+{
+    if (ctx == NULL || ctx->events_row == NULL)
+    {
+        return;
+    }
+
+    lv_obj_clean(ctx->events_row);
+    clear_event_slots(ctx);
+
+    if (events == NULL || event_count == 0)
+    {
+        lv_obj_t* placeholder = lv_label_create(ctx->events_row);
+        lv_label_set_text(placeholder, "No recent activity");
+        lv_obj_set_style_text_font(placeholder, &lv_font_montserrat_18, LV_PART_MAIN);
+        lv_obj_set_style_text_color(placeholder, ui_theme_color_muted(), LV_PART_MAIN);
+
+        if (ctx->timeline_button != NULL)
+        {
+            lv_obj_add_state(ctx->timeline_button, LV_STATE_DISABLED);
+        }
+        return;
+    }
+
+    ctx->event_slots =
+        (ui_page_cctv_event_slot_t*)lv_malloc(sizeof(ui_page_cctv_event_slot_t) * event_count);
+    if (ctx->event_slots == NULL)
+    {
+        ctx->event_count = 0;
+        return;
+    }
+    lv_memset_00(ctx->event_slots, sizeof(ui_page_cctv_event_slot_t) * event_count);
+
+    size_t created = 0;
+
+    for (size_t i = 0; i < event_count; i++)
+    {
+        const ui_page_cctv_event_t* source = &events[i];
+
+        ui_room_card_config_t event_config = {
+            .room_id   = source->event_id,
+            .title     = source->title,
+            .icon_text = LV_SYMBOL_VIDEO,
+        };
+
+        ui_room_card_t* event_card = ui_room_card_create(ctx->events_row, &event_config);
+        if (event_card == NULL)
+        {
+            continue;
+        }
+
+        lv_obj_t* event_obj = ui_room_card_get_obj(event_card);
+        lv_obj_set_width(event_obj, 280);
+        lv_obj_set_style_pad_gap(event_obj, 16, LV_PART_MAIN);
+
+        lv_obj_t* toggle = ui_room_card_get_toggle(event_card);
+        if (toggle != NULL)
+        {
+            lv_obj_add_flag(toggle, LV_OBJ_FLAG_HIDDEN);
+        }
+
+        lv_obj_t* description = lv_label_create(event_obj);
+        if (source->description != NULL)
+        {
+            lv_label_set_text(description, source->description);
+        }
+        else
+        {
+            lv_label_set_text(description, "No description");
+        }
+        lv_obj_set_style_text_font(description, &lv_font_montserrat_18, LV_PART_MAIN);
+        lv_obj_set_style_text_color(description, ui_theme_color_on_surface(), LV_PART_MAIN);
+        lv_label_set_long_mode(description, LV_LABEL_LONG_WRAP);
+        lv_obj_set_width(description, LV_PCT(100));
+
+        lv_obj_t* time_label = lv_obj_get_child(event_obj, -1);
+        if (time_label != NULL)
+        {
+            if (source->timestamp != NULL)
+            {
+                lv_label_set_text(time_label, source->timestamp);
+            }
+            else
+            {
+                lv_label_set_text(time_label, "");
+            }
+            lv_obj_set_style_text_color(time_label, ui_theme_color_muted(), LV_PART_MAIN);
+        }
+
+        ui_page_cctv_event_slot_t* slot = &ctx->event_slots[created++];
+        slot->card_obj                  = event_obj;
+        slot->event.event_id            = duplicate_string(source->event_id);
+        slot->event.camera_id           = duplicate_string(source->camera_id);
+        slot->event.title               = duplicate_string(source->title);
+        slot->event.description         = duplicate_string(source->description);
+        slot->event.timestamp           = duplicate_string(source->timestamp);
+        slot->event.clip_url            = duplicate_string(source->clip_url);
+        slot->event.snapshot_url        = duplicate_string(source->snapshot_url);
+
+        lv_obj_add_event_cb(event_obj, event_card_clicked_cb, LV_EVENT_CLICKED, ctx);
+    }
+
+    ctx->event_count = created;
+
+    if (ctx->timeline_button != NULL)
+    {
+        if (ctx->event_count > 0)
+        {
+            lv_obj_clear_state(ctx->timeline_button, LV_STATE_DISABLED);
+        }
+        else
+        {
+            lv_obj_add_state(ctx->timeline_button, LV_STATE_DISABLED);
+        }
+    }
+
+    if (created == 0)
+    {
+        lv_free(ctx->event_slots);
+        ctx->event_slots = NULL;
+
+        lv_obj_t* placeholder = lv_label_create(ctx->events_row);
+        lv_label_set_text(placeholder, "No recent activity");
+        lv_obj_set_style_text_font(placeholder, &lv_font_montserrat_18, LV_PART_MAIN);
+        lv_obj_set_style_text_color(placeholder, ui_theme_color_muted(), LV_PART_MAIN);
+    }
+}
+
+static void toolbar_button_cb(lv_event_t* event)
+{
+    if (event == NULL)
+    {
+        return;
+    }
+
+    ui_page_cctv_ctx_t* ctx = (ui_page_cctv_ctx_t*)lv_event_get_user_data(event);
+    if (ctx == NULL || ctx->page == NULL)
+    {
+        return;
+    }
+
+    lv_obj_t* target = lv_event_get_target(event);
+    if (lv_obj_has_state(target, LV_STATE_DISABLED))
+    {
+        return;
+    }
+
+    ui_page_cctv_action_t action;
+
+    if (target == ctx->prev_btn)
+    {
+        action = UI_PAGE_CCTV_ACTION_PREVIOUS;
+    }
+    else if (target == ctx->next_btn)
+    {
+        action = UI_PAGE_CCTV_ACTION_NEXT;
+    }
+    else if (target == ctx->quality_btn)
+    {
+        action = UI_PAGE_CCTV_ACTION_QUALITY;
+    }
+    else if (target == ctx->mute_btn)
+    {
+        action = UI_PAGE_CCTV_ACTION_TOGGLE_MUTE;
+    }
+    else
+    {
+        return;
+    }
+
+    ui_page_cctv_action_event_t data = {
+        .action        = action,
+        .camera_index  = ctx->active_index,
+        .camera_count  = ctx->camera_count,
+        .camera_id     = ctx->active_camera_id,
+        .stream_url    = ctx->active_stream_url,
+        .quality_label = ctx->quality_label_text,
+        .muted         = ctx->muted,
+    };
+
+    lv_event_send(ctx->page, UI_PAGE_CCTV_EVENT_ACTION, &data);
+}
+
+static void action_button_cb(lv_event_t* event)
+{
+    if (event == NULL)
+    {
+        return;
+    }
+
+    ui_page_cctv_ctx_t* ctx = (ui_page_cctv_ctx_t*)lv_event_get_user_data(event);
+    if (ctx == NULL || ctx->page == NULL)
+    {
+        return;
+    }
+
+    lv_obj_t* target = lv_event_get_target(event);
+    if (lv_obj_has_state(target, LV_STATE_DISABLED))
+    {
+        return;
+    }
+
+    ui_page_cctv_action_t action;
+
+    if (target == ctx->open_gate_button)
+    {
+        action = UI_PAGE_CCTV_ACTION_OPEN_GATE;
+    }
+    else if (target == ctx->talk_button)
+    {
+        action = UI_PAGE_CCTV_ACTION_TALK;
+    }
+    else if (target == ctx->snapshot_button)
+    {
+        action = UI_PAGE_CCTV_ACTION_SNAPSHOT;
+    }
+    else if (target == ctx->timeline_button)
+    {
+        action = UI_PAGE_CCTV_ACTION_TIMELINE;
+    }
+    else
+    {
+        return;
+    }
+
+    ui_page_cctv_action_event_t data = {
+        .action        = action,
+        .camera_index  = ctx->active_index,
+        .camera_count  = ctx->camera_count,
+        .camera_id     = ctx->active_camera_id,
+        .stream_url    = ctx->active_stream_url,
+        .quality_label = ctx->quality_label_text,
+        .muted         = ctx->muted,
+    };
+
+    lv_event_send(ctx->page, UI_PAGE_CCTV_EVENT_ACTION, &data);
+}
+
+static void hide_toggle(ui_room_card_t* card)
+{
+    if (card == NULL)
+    {
+        return;
+    }
+
+    lv_obj_t* toggle = ui_room_card_get_toggle(card);
+    if (toggle != NULL)
+    {
+        lv_obj_add_flag(toggle, LV_OBJ_FLAG_HIDDEN);
+    }
+}
+
+static lv_obj_t* create_toolbar(ui_page_cctv_ctx_t* ctx)
+{
+    lv_obj_t* toolbar = lv_obj_create(ctx->content);
     lv_obj_remove_style_all(toolbar);
     lv_obj_set_width(toolbar, LV_PCT(100));
     lv_obj_set_style_bg_color(toolbar, ui_theme_color_surface(), LV_PART_MAIN);
@@ -63,8 +630,10 @@ static lv_obj_t* ui_page_create_content(lv_obj_t* page, const char* title_text)
     lv_label_set_text(prev_label, LV_SYMBOL_LEFT " Prev");
     lv_obj_set_style_text_font(prev_label, &lv_font_montserrat_18, LV_PART_MAIN);
 
+    lv_obj_add_event_cb(prev_btn, toolbar_button_cb, LV_EVENT_CLICKED, ctx);
+
     lv_obj_t* camera_label = lv_label_create(toolbar);
-    lv_label_set_text(camera_label, "Camera 2 of 6");
+    lv_label_set_text(camera_label, "No cameras");
     lv_obj_set_style_text_font(camera_label, &lv_font_montserrat_20, LV_PART_MAIN);
     lv_obj_set_style_text_color(camera_label, ui_theme_color_on_surface(), LV_PART_MAIN);
 
@@ -81,6 +650,8 @@ static lv_obj_t* ui_page_create_content(lv_obj_t* page, const char* title_text)
     lv_label_set_text(next_label, "Next " LV_SYMBOL_RIGHT);
     lv_obj_set_style_text_font(next_label, &lv_font_montserrat_18, LV_PART_MAIN);
 
+    lv_obj_add_event_cb(next_btn, toolbar_button_cb, LV_EVENT_CLICKED, ctx);
+
     lv_obj_t* quality_btn = lv_btn_create(toolbar);
     lv_obj_remove_style_all(quality_btn);
     lv_obj_set_style_bg_color(quality_btn, ui_theme_color_surface(), LV_PART_MAIN);
@@ -95,6 +666,8 @@ static lv_obj_t* ui_page_create_content(lv_obj_t* page, const char* title_text)
     lv_obj_t* quality_label = lv_label_create(quality_btn);
     lv_label_set_text(quality_label, "Quality ▾");
     lv_obj_set_style_text_font(quality_label, &lv_font_montserrat_18, LV_PART_MAIN);
+
+    lv_obj_add_event_cb(quality_btn, toolbar_button_cb, LV_EVENT_CLICKED, ctx);
 
     lv_obj_t* mute_btn = lv_btn_create(toolbar);
     lv_obj_remove_style_all(mute_btn);
@@ -111,136 +684,180 @@ static lv_obj_t* ui_page_create_content(lv_obj_t* page, const char* title_text)
     lv_label_set_text(mute_label, LV_SYMBOL_AUDIO " Mute");
     lv_obj_set_style_text_font(mute_label, &lv_font_montserrat_18, LV_PART_MAIN);
 
-    ui_room_card_config_t camera_config = {
-        .room_id   = "cctv_main",
-        .title     = "Backyard Camera",
+    lv_obj_add_event_cb(mute_btn, toolbar_button_cb, LV_EVENT_CLICKED, ctx);
+
+    ctx->toolbar            = toolbar;
+    ctx->prev_btn           = prev_btn;
+    ctx->next_btn           = next_btn;
+    ctx->quality_btn        = quality_btn;
+    ctx->mute_btn           = mute_btn;
+    ctx->camera_index_label = camera_label;
+    ctx->quality_label      = quality_label;
+    ctx->mute_label         = mute_label;
+
+    return toolbar;
+}
+
+static void create_camera_section(ui_page_cctv_ctx_t* ctx)
+{
+    ui_room_card_config_t config = {
+        .room_id   = "cctv_primary",
+        .title     = "Camera",
         .icon_text = LV_SYMBOL_EYE_OPEN,
     };
 
-    ui_room_card_t* camera_card     = ui_room_card_create(content, &camera_config);
-    lv_obj_t*       camera_card_obj = ui_room_card_get_obj(camera_card);
-    lv_obj_set_style_pad_gap(camera_card_obj, 24, LV_PART_MAIN);
-
-    lv_obj_t* camera_toggle = ui_room_card_get_toggle(camera_card);
-    if (camera_toggle != NULL)
+    ctx->camera_card = ui_room_card_create(ctx->content, &config);
+    if (ctx->camera_card == NULL)
     {
-        lv_obj_add_flag(camera_toggle, LV_OBJ_FLAG_HIDDEN);
+        return;
     }
 
-    lv_obj_t* camera_specs = lv_obj_get_child(camera_card_obj, -1);
-    if (camera_specs != NULL)
+    lv_obj_t* card_obj = ui_room_card_get_obj(ctx->camera_card);
+    lv_obj_set_style_pad_gap(card_obj, 24, LV_PART_MAIN);
+
+    lv_obj_t* header = lv_obj_get_child(card_obj, 0);
+    if (header != NULL)
     {
-        lv_label_set_text(camera_specs, "Streaming · 1080p60");
+        ctx->camera_title_label = lv_obj_get_child(header, 1);
     }
+    ctx->camera_specs_label = lv_obj_get_child(card_obj, -1);
 
-    lv_obj_t* video = lv_obj_create(camera_card_obj);
-    lv_obj_remove_style_all(video);
-    lv_obj_set_width(video, LV_PCT(100));
-    lv_obj_set_height(video, 280);
-    lv_obj_set_style_bg_color(video, ui_theme_color_outline(), LV_PART_MAIN);
-    lv_obj_set_style_bg_opa(video, LV_OPA_30, LV_PART_MAIN);
-    lv_obj_set_style_radius(video, 18, LV_PART_MAIN);
-    lv_obj_set_style_border_width(video, 0, LV_PART_MAIN);
-    lv_obj_set_style_pad_all(video, 24, LV_PART_MAIN);
+    hide_toggle(ctx->camera_card);
 
-    lv_obj_t* video_label = lv_label_create(video);
-    lv_label_set_text(video_label, "Live feed (stub)");
-    lv_obj_set_style_text_font(video_label, &lv_font_montserrat_22, LV_PART_MAIN);
-    lv_obj_set_style_text_color(video_label, ui_theme_color_on_surface(), LV_PART_MAIN);
-    lv_obj_center(video_label);
+    ctx->video_container = lv_obj_create(card_obj);
+    lv_obj_remove_style_all(ctx->video_container);
+    lv_obj_set_width(ctx->video_container, LV_PCT(100));
+    lv_obj_set_height(ctx->video_container, 280);
+    lv_obj_set_style_bg_color(ctx->video_container, ui_theme_color_outline(), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(ctx->video_container, LV_OPA_30, LV_PART_MAIN);
+    lv_obj_set_style_radius(ctx->video_container, 18, LV_PART_MAIN);
+    lv_obj_set_style_border_width(ctx->video_container, 0, LV_PART_MAIN);
+    lv_obj_set_style_pad_all(ctx->video_container, 24, LV_PART_MAIN);
 
-    lv_obj_t* events_row = lv_obj_create(content);
-    lv_obj_remove_style_all(events_row);
-    lv_obj_set_width(events_row, LV_PCT(100));
-    lv_obj_set_style_bg_opa(events_row, LV_OPA_TRANSP, LV_PART_MAIN);
-    lv_obj_set_style_pad_gap(events_row, 24, LV_PART_MAIN);
-    lv_obj_set_flex_flow(events_row, LV_FLEX_FLOW_ROW_WRAP);
+    ctx->stream_label = lv_label_create(ctx->video_container);
+    lv_label_set_text(ctx->stream_label, "Live feed (stub)");
+    lv_obj_set_style_text_font(ctx->stream_label, &lv_font_montserrat_22, LV_PART_MAIN);
+    lv_obj_set_style_text_color(ctx->stream_label, ui_theme_color_on_surface(), LV_PART_MAIN);
+    lv_obj_center(ctx->stream_label);
+}
+
+static void create_events_section(ui_page_cctv_ctx_t* ctx)
+{
+    ctx->events_row = lv_obj_create(ctx->content);
+    lv_obj_remove_style_all(ctx->events_row);
+    lv_obj_set_width(ctx->events_row, LV_PCT(100));
+    lv_obj_set_style_bg_opa(ctx->events_row, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_style_pad_gap(ctx->events_row, 24, LV_PART_MAIN);
+    lv_obj_set_flex_flow(ctx->events_row, LV_FLEX_FLOW_ROW_WRAP);
     lv_obj_set_flex_align(
-        events_row, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+        ctx->events_row, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+}
 
-    static const struct
+static void create_actions_section(ui_page_cctv_ctx_t* ctx)
+{
+    ctx->actions_row = lv_obj_create(ctx->content);
+    lv_obj_remove_style_all(ctx->actions_row);
+    lv_obj_set_width(ctx->actions_row, LV_PCT(100));
+    lv_obj_set_style_bg_opa(ctx->actions_row, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_style_pad_gap(ctx->actions_row, 24, LV_PART_MAIN);
+    lv_obj_set_flex_flow(ctx->actions_row, LV_FLEX_FLOW_ROW_WRAP);
+    lv_obj_set_flex_align(
+        ctx->actions_row, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+    struct
     {
-        const char* room_id;
-        const char* title;
-        const char* description;
-        const char* timestamp;
-    } k_event_cards[] = {
-        {"door", "Front Door", "Person @ Door – 2m", "Today · 12:42"},
-        {"garage", "Garage", "Motion – 5m", "Today · 12:37"},
-        {"yard", "Backyard", "Person @ Gate – 8m", "Today · 12:20"},
-        {"drive", "Driveway", "Vehicle Detected", "Today · 11:58"},
+        const char*           label;
+        ui_page_cctv_action_t action;
+        lv_obj_t**            slot;
+    } buttons[] = {
+        {"Open Gate", UI_PAGE_CCTV_ACTION_OPEN_GATE, &ctx->open_gate_button},
+        {"Talk", UI_PAGE_CCTV_ACTION_TALK, &ctx->talk_button},
+        {"Snapshot", UI_PAGE_CCTV_ACTION_SNAPSHOT, &ctx->snapshot_button},
+        {"Timeline ▾", UI_PAGE_CCTV_ACTION_TIMELINE, &ctx->timeline_button},
     };
 
-    for (size_t i = 0; i < (sizeof(k_event_cards) / sizeof(k_event_cards[0])); i++)
+    for (size_t i = 0; i < (sizeof(buttons) / sizeof(buttons[0])); i++)
     {
-        ui_room_card_config_t event_config = {
-            .room_id   = k_event_cards[i].room_id,
-            .title     = k_event_cards[i].title,
-            .icon_text = LV_SYMBOL_VIDEO,
-        };
+        lv_obj_t* button = lv_btn_create(ctx->actions_row);
+        lv_obj_remove_style_all(button);
+        lv_obj_set_style_bg_color(button, ui_theme_color_surface(), LV_PART_MAIN);
+        lv_obj_set_style_bg_opa(button, LV_OPA_80, LV_PART_MAIN);
+        lv_obj_set_style_radius(button, 26, LV_PART_MAIN);
+        lv_obj_set_style_border_width(button, 1, LV_PART_MAIN);
+        lv_obj_set_style_border_color(button, ui_theme_color_outline(), LV_PART_MAIN);
+        lv_obj_set_style_pad_hor(button, 28, LV_PART_MAIN);
+        lv_obj_set_style_pad_ver(button, 16, LV_PART_MAIN);
+        lv_obj_set_style_shadow_width(button, 0, LV_PART_MAIN);
+        lv_obj_set_style_text_color(button, ui_theme_color_on_surface(), LV_PART_MAIN);
 
-        ui_room_card_t* event_card = ui_room_card_create(events_row, &event_config);
-        lv_obj_t*       event_obj  = ui_room_card_get_obj(event_card);
-        lv_obj_set_width(event_obj, 280);
-        lv_obj_set_style_pad_gap(event_obj, 16, LV_PART_MAIN);
+        lv_obj_t* label = lv_label_create(button);
+        lv_label_set_text(label, buttons[i].label);
+        lv_obj_set_style_text_font(label, &lv_font_montserrat_18, LV_PART_MAIN);
 
-        lv_obj_t* event_toggle = ui_room_card_get_toggle(event_card);
-        if (event_toggle != NULL)
-        {
-            lv_obj_add_flag(event_toggle, LV_OBJ_FLAG_HIDDEN);
-        }
-
-        lv_obj_t* event_description = lv_label_create(event_obj);
-        lv_label_set_text(event_description, k_event_cards[i].description);
-        lv_obj_set_style_text_font(event_description, &lv_font_montserrat_18, LV_PART_MAIN);
-        lv_obj_set_style_text_color(event_description, ui_theme_color_on_surface(), LV_PART_MAIN);
-        lv_label_set_long_mode(event_description, LV_LABEL_LONG_WRAP);
-        lv_obj_set_width(event_description, LV_PCT(100));
-
-        lv_obj_t* event_time = lv_obj_get_child(event_obj, -1);
-        if (event_time != NULL)
-        {
-            lv_label_set_text(event_time, k_event_cards[i].timestamp);
-            lv_obj_set_style_text_color(event_time, ui_theme_color_muted(), LV_PART_MAIN);
-        }
+        lv_obj_add_event_cb(button, action_button_cb, LV_EVENT_CLICKED, ctx);
+        *buttons[i].slot = button;
     }
+}
 
-    lv_obj_t* actions_row = lv_obj_create(content);
-    lv_obj_remove_style_all(actions_row);
-    lv_obj_set_width(actions_row, LV_PCT(100));
-    lv_obj_set_style_bg_opa(actions_row, LV_OPA_TRANSP, LV_PART_MAIN);
-    lv_obj_set_style_pad_gap(actions_row, 24, LV_PART_MAIN);
-    lv_obj_set_flex_flow(actions_row, LV_FLEX_FLOW_ROW_WRAP);
-    lv_obj_set_flex_align(
-        actions_row, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+static lv_obj_t* create_content(ui_page_cctv_ctx_t* ctx)
+{
+    lv_obj_t* content = lv_obj_create(ctx->page);
+    lv_obj_remove_style_all(content);
+    lv_obj_set_size(content, LV_PCT(100), LV_PCT(100));
+    lv_obj_set_style_bg_opa(content, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_style_pad_left(content, 192, LV_PART_MAIN);
+    lv_obj_set_style_pad_right(content, 48, LV_PART_MAIN);
+    lv_obj_set_style_pad_top(content, 48, LV_PART_MAIN);
+    lv_obj_set_style_pad_bottom(content, 48, LV_PART_MAIN);
+    lv_obj_set_style_pad_gap(content, 32, LV_PART_MAIN);
+    lv_obj_set_flex_flow(content, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(content, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
 
-    static const char* k_actions[] = {
-        "Open Gate",
-        "Talk",
-        "Snapshot",
-        "Timeline ▾",
-    };
+    lv_obj_t* title = lv_label_create(content);
+    lv_label_set_text(title, "Frigate Security");
+    lv_obj_set_style_text_font(title, &lv_font_montserrat_32, LV_PART_MAIN);
+    lv_obj_set_style_text_color(title, ui_theme_color_on_surface(), LV_PART_MAIN);
 
-    for (size_t i = 0; i < (sizeof(k_actions) / sizeof(k_actions[0])); i++)
-    {
-        lv_obj_t* action_btn = lv_btn_create(actions_row);
-        lv_obj_remove_style_all(action_btn);
-        lv_obj_set_style_bg_color(action_btn, ui_theme_color_surface(), LV_PART_MAIN);
-        lv_obj_set_style_bg_opa(action_btn, LV_OPA_80, LV_PART_MAIN);
-        lv_obj_set_style_radius(action_btn, 26, LV_PART_MAIN);
-        lv_obj_set_style_border_width(action_btn, 1, LV_PART_MAIN);
-        lv_obj_set_style_border_color(action_btn, ui_theme_color_outline(), LV_PART_MAIN);
-        lv_obj_set_style_pad_hor(action_btn, 28, LV_PART_MAIN);
-        lv_obj_set_style_pad_ver(action_btn, 16, LV_PART_MAIN);
-        lv_obj_set_style_shadow_width(action_btn, 0, LV_PART_MAIN);
-        lv_obj_set_style_text_color(action_btn, ui_theme_color_on_surface(), LV_PART_MAIN);
+    ctx->content = content;
 
-        lv_obj_t* action_label = lv_label_create(action_btn);
-        lv_label_set_text(action_label, k_actions[i]);
-        lv_obj_set_style_text_font(action_label, &lv_font_montserrat_18, LV_PART_MAIN);
-    }
+    create_toolbar(ctx);
+    create_camera_section(ctx);
+    create_events_section(ctx);
+    create_actions_section(ctx);
 
     return content;
+}
+
+static void ui_page_cctv_delete_cb(lv_event_t* event)
+{
+    if (event == NULL)
+    {
+        return;
+    }
+
+    ui_page_cctv_ctx_t* ctx = (ui_page_cctv_ctx_t*)lv_event_get_user_data(event);
+    if (ctx == NULL)
+    {
+        return;
+    }
+
+    if (ctx->wallpaper != NULL)
+    {
+        ui_wallpaper_detach(ctx->wallpaper);
+        ctx->wallpaper = NULL;
+    }
+
+    replace_string(&ctx->active_camera_id, NULL);
+    replace_string(&ctx->active_stream_url, NULL);
+    replace_string(&ctx->quality_label_text, NULL);
+    clear_event_slots(ctx);
+
+    if (s_ctx == ctx)
+    {
+        s_ctx = NULL;
+    }
+
+    lv_free(ctx);
 }
 
 lv_obj_t* ui_page_cctv_create(lv_obj_t* parent)
@@ -250,21 +867,117 @@ lv_obj_t* ui_page_cctv_create(lv_obj_t* parent)
         return NULL;
     }
 
-    lv_obj_t* page = lv_obj_create(parent);
-    lv_obj_remove_style_all(page);
-    lv_obj_set_size(page, LV_PCT(100), LV_PCT(100));
-    lv_obj_set_style_bg_opa(page, LV_OPA_TRANSP, LV_PART_MAIN);
-    lv_obj_set_scroll_dir(page, LV_DIR_VER);
-    lv_obj_set_scrollbar_mode(page, LV_SCROLLBAR_MODE_OFF);
-    lv_obj_add_flag(page, LV_OBJ_FLAG_CLICKABLE);
-
-    ui_wallpaper_t* wallpaper = ui_wallpaper_attach(page);
-    if (wallpaper != NULL)
+    ui_page_cctv_ctx_t* ctx = (ui_page_cctv_ctx_t*)lv_malloc(sizeof(ui_page_cctv_ctx_t));
+    if (ctx == NULL)
     {
-        lv_obj_add_event_cb(page, ui_page_cctv_delete_cb, LV_EVENT_DELETE, wallpaper);
+        return NULL;
+    }
+    lv_memset_00(ctx, sizeof(ui_page_cctv_ctx_t));
+
+    ctx->page = lv_obj_create(parent);
+    if (ctx->page == NULL)
+    {
+        lv_free(ctx);
+        return NULL;
     }
 
-    ui_page_create_content(page, "Frigate Security");
+    lv_obj_remove_style_all(ctx->page);
+    lv_obj_set_size(ctx->page, LV_PCT(100), LV_PCT(100));
+    lv_obj_set_style_bg_opa(ctx->page, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_scroll_dir(ctx->page, LV_DIR_VER);
+    lv_obj_set_scrollbar_mode(ctx->page, LV_SCROLLBAR_MODE_OFF);
+    lv_obj_add_flag(ctx->page, LV_OBJ_FLAG_CLICKABLE);
 
-    return page;
+    ctx->wallpaper = ui_wallpaper_attach(ctx->page);
+
+    create_content(ctx);
+    update_toolbar(ctx);
+    update_camera_card(ctx, NULL);
+    update_events(ctx, NULL, 0);
+
+    lv_obj_add_event_cb(ctx->page, ui_page_cctv_delete_cb, LV_EVENT_DELETE, ctx);
+
+    s_ctx = ctx;
+
+    return ctx->page;
+}
+
+lv_obj_t* ui_page_cctv_get_obj(void)
+{
+    return s_ctx != NULL ? s_ctx->page : NULL;
+}
+
+void ui_page_cctv_set_state(const ui_page_cctv_state_t* state)
+{
+    if (s_ctx == NULL)
+    {
+        return;
+    }
+
+    const ui_page_cctv_camera_t* camera = NULL;
+
+    if (state != NULL && state->cameras != NULL && state->camera_count > 0)
+    {
+        s_ctx->camera_count = state->camera_count;
+        if (state->active_index < state->camera_count)
+        {
+            s_ctx->active_index = state->active_index;
+        }
+        else
+        {
+            s_ctx->active_index = 0;
+        }
+        camera = &state->cameras[s_ctx->active_index];
+    }
+    else
+    {
+        s_ctx->camera_count = 0;
+        s_ctx->active_index = 0;
+    }
+
+    if (state != NULL)
+    {
+        s_ctx->muted = state->muted;
+    }
+    else
+    {
+        s_ctx->muted = false;
+    }
+
+    if (camera != NULL)
+    {
+        replace_string(&s_ctx->active_camera_id, camera->camera_id);
+        replace_string(&s_ctx->active_stream_url, camera->stream_url);
+        s_ctx->audio_supported = camera->audio_supported;
+    }
+    else
+    {
+        replace_string(&s_ctx->active_camera_id, NULL);
+        replace_string(&s_ctx->active_stream_url, NULL);
+        s_ctx->audio_supported = false;
+    }
+
+    if (state != NULL)
+    {
+        replace_string(&s_ctx->quality_label_text, state->quality_label);
+    }
+    else
+    {
+        replace_string(&s_ctx->quality_label_text, NULL);
+    }
+
+    update_toolbar(s_ctx);
+    update_camera_card(s_ctx, camera);
+    update_events(
+        s_ctx, state != NULL ? state->events : NULL, state != NULL ? state->event_count : 0);
+}
+
+void ui_page_cctv_set_events(const ui_page_cctv_event_t* events, size_t event_count)
+{
+    if (s_ctx == NULL)
+    {
+        return;
+    }
+
+    update_events(s_ctx, events, event_count);
 }

--- a/custom/ui/pages/ui_page_cctv.h
+++ b/custom/ui/pages/ui_page_cctv.h
@@ -5,18 +5,97 @@
  */
 #pragma once
 
+#include <stdbool.h>
+#include <stddef.h>
+
 #ifdef __has_include
-#if __has_include("lvgl.h")
-#ifndef LV_LVGL_H_INCLUDE_SIMPLE
-#define LV_LVGL_H_INCLUDE_SIMPLE
-#endif
-#endif
+#    if __has_include("lvgl.h")
+#        ifndef LV_LVGL_H_INCLUDE_SIMPLE
+#            define LV_LVGL_H_INCLUDE_SIMPLE
+#        endif
+#    endif
 #endif
 
 #if defined(LV_LVGL_H_INCLUDE_SIMPLE)
-#include "lvgl.h"
+#    include "lvgl.h"
 #else
-#include "lvgl/lvgl.h"
+#    include "lvgl/lvgl.h"
 #endif
 
-lv_obj_t *ui_page_cctv_create(lv_obj_t *parent);
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct
+    {
+        const char* camera_id;
+        const char* name;
+        const char* status;
+        const char* stream_url;
+        const char* snapshot_url;
+        bool        audio_supported;
+    } ui_page_cctv_camera_t;
+
+    typedef struct
+    {
+        const char* event_id;
+        const char* camera_id;
+        const char* title;
+        const char* description;
+        const char* timestamp;
+        const char* clip_url;
+        const char* snapshot_url;
+    } ui_page_cctv_event_t;
+
+    typedef struct
+    {
+        const ui_page_cctv_camera_t* cameras;
+        size_t                       camera_count;
+        size_t                       active_index;
+        const ui_page_cctv_event_t*  events;
+        size_t                       event_count;
+        const char*                  quality_label;
+        bool                         muted;
+    } ui_page_cctv_state_t;
+
+    typedef enum
+    {
+        UI_PAGE_CCTV_ACTION_PREVIOUS = 0,
+        UI_PAGE_CCTV_ACTION_NEXT,
+        UI_PAGE_CCTV_ACTION_QUALITY,
+        UI_PAGE_CCTV_ACTION_TOGGLE_MUTE,
+        UI_PAGE_CCTV_ACTION_OPEN_GATE,
+        UI_PAGE_CCTV_ACTION_TALK,
+        UI_PAGE_CCTV_ACTION_SNAPSHOT,
+        UI_PAGE_CCTV_ACTION_TIMELINE,
+    } ui_page_cctv_action_t;
+
+    typedef struct
+    {
+        ui_page_cctv_action_t action;
+        size_t                camera_index;
+        size_t                camera_count;
+        const char*           camera_id;
+        const char*           stream_url;
+        const char*           quality_label;
+        bool                  muted;
+    } ui_page_cctv_action_event_t;
+
+    typedef struct
+    {
+        const ui_page_cctv_event_t* event;
+        size_t                      index;
+    } ui_page_cctv_clip_event_t;
+
+#define UI_PAGE_CCTV_EVENT_ACTION    ((lv_event_code_t)(LV_EVENT_LAST + 10))
+#define UI_PAGE_CCTV_EVENT_OPEN_CLIP ((lv_event_code_t)(LV_EVENT_LAST + 11))
+
+    lv_obj_t* ui_page_cctv_create(lv_obj_t* parent);
+    lv_obj_t* ui_page_cctv_get_obj(void);
+    void      ui_page_cctv_set_state(const ui_page_cctv_state_t* state);
+    void      ui_page_cctv_set_events(const ui_page_cctv_event_t* events, size_t event_count);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary
- define CCTV page data model, action events, and setters for cameras and clip history
- refactor the CCTV page to render dynamic state, surface LVGL events, and manage event chips
- add a Frigate-inspired integration controller and hook it into the launcher to seed the UI

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5a35c21483248afa2b692def3e59