### PR TITLE
fix: register core component for Tab5 build

### DIFF
--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(PROJECT_COMPONENTS
+    core
     settings_core
     settings_ui
     connection_tester

--- a/components/core/CMakeLists.txt
+++ b/components/core/CMakeLists.txt
@@ -1,0 +1,7 @@
+idf_component_register(
+    SRCS
+        "src/ringbuf.cpp"
+        "src/settings.cpp"
+    INCLUDE_DIRS
+        "include"
+)

--- a/custom/integration/settings_controller.cpp
+++ b/custom/integration/settings_controller.cpp
@@ -21,7 +21,7 @@
 #include <thread>
 #include <vector>
 
-#include "core/app_trace.h"
+#include "app_trace.h"
 #include "hal/hal.h"
 #include "settings_core/app_cfg.h"
 #include "settings_ui/settings_ui.h"


### PR DESCRIPTION
## Summary
- register the core component so its headers are exported to the include path
- include app_trace via the component's public header rather than a nested path
- add a minimal CMakeLists.txt for the core component sources

## Testing
- `idf.py build` *(fails: command not found; ESP-IDF not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd61c0ce708324a19e5bb6bf8754ec