### PR TITLE
fix: map APP_TRACEI to APP_LOG_INFO

### DIFF
--- a/components/core/include/app_trace.h
+++ b/components/core/include/app_trace.h
@@ -110,6 +110,7 @@ inline void Trace(const char* section, const char* event, const char* fmt = null
 #define APP_LOG_WARN(tag, fmt, ...)  ::app_trace::Log(::app_trace::Level::kWarning, tag, fmt, ##__VA_ARGS__)
 #define APP_LOG_INFO(tag, fmt, ...)  ::app_trace::Log(::app_trace::Level::kInfo, tag, fmt, ##__VA_ARGS__)
 #define APP_LOG_DEBUG(tag, fmt, ...) ::app_trace::Log(::app_trace::Level::kDebug, tag, fmt, ##__VA_ARGS__)
+#define APP_TRACEI(tag, fmt, ...)    APP_LOG_INFO(tag, fmt, ##__VA_ARGS__)
 
 #define APP_ASSERT(expr)                                                                                     \
     do {                                                                                                     \


### PR DESCRIPTION
## Summary
- add an APP_TRACEI alias that forwards to APP_LOG_INFO so existing uses compile again

## Testing
- idf.py build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6fbe55988324942463a6b7d78693