### PR TITLE
fix: clean CCTV clip event handler

### DIFF
--- a/custom/integration/cctv_controller.cpp
+++ b/custom/integration/cctv_controller.cpp
@@ -133,16 +133,14 @@ namespace custom::integration
                 controller->HandleAction(*action);
             }
         }
-        +else if (code == UI_PAGE_CCTV_EVENT_OPEN_CLIP) +
+        else if (code == UI_PAGE_CCTV_EVENT_OPEN_CLIP)
         {
-            +const auto* clip =
+            const auto* clip =
                 static_cast<const ui_page_cctv_clip_event_t*>(lv_event_get_param(event));
-            +if (clip != nullptr) +
+            if (clip != nullptr)
             {
-                +controller->HandleClipRequest(*clip);
-                +
+                controller->HandleClipRequest(*clip);
             }
-            +
         }
     }
 


### PR DESCRIPTION
## Summary
- remove the stray diff markers around the CCTV clip event handler
- keep casting the clip event payload before forwarding it to HandleClipRequest

## Testing
- idf.py build *(fails: `idf.py` not found on PATH in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6fbf75048324a5c3d66b98deea0b