### PR TITLE
fix(app_launcher): include integration controller headers

### DIFF
--- a/app/apps/app_launcher/view/view.h
+++ b/app/apps/app_launcher/view/view.h
@@ -12,6 +12,8 @@
 #include <smooth_ui_toolkit.h>
 #include <vector>
 
+#include "integration/cctv_controller.h"
+#include "integration/media_controller.h"
 #include "integration/settings_controller.h"
 
 namespace custom::integration


### PR DESCRIPTION
## Summary
- include the CCTV and media controller headers so the launcher view sees their class definitions

## Testing
- ./scripts/idf.py build *(fails: IDF_PATH: unbound variable)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7cccaabc8324b392561cbdd0decb