### PR TITLE
fix: add cctv controller using directive

### DIFF
--- a/app/apps/app_launcher/view/view.cpp
+++ b/app/apps/app_launcher/view/view.cpp
@@ -22,6 +22,7 @@
 using namespace launcher_view;
 using namespace smooth_ui_toolkit;
 using namespace smooth_ui_toolkit::lvgl_cpp;
+using custom::integration::CctvController;
 using custom::integration::MediaController;
 using custom::integration::SettingsController;
 


### PR DESCRIPTION
## Summary
- add the missing using directive for `custom::integration::CctvController` so the launcher view can instantiate it without qualification

## Testing
- `idf.py build` *(fails: `idf.py`: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7cd5ecec8324a708ac848ee377dd