### PR TITLE
fix: adjust app_trace include path in integration controllers

### DIFF
--- a/custom/integration/cctv_controller.cpp
+++ b/custom/integration/cctv_controller.cpp
@@ -8,7 +8,7 @@
 #include <algorithm>
 #include <array>
 
-#include "core/app_trace.h"
+#include "app_trace.h"
 
 namespace custom::integration
 {

--- a/custom/integration/media_controller.cpp
+++ b/custom/integration/media_controller.cpp
@@ -8,7 +8,7 @@
 #include <algorithm>
 #include <array>
 
-#include "core/app_trace.h"
+#include "app_trace.h"
 
 namespace custom::integration
 {


### PR DESCRIPTION
## Summary
- update the app trace include in the media and CCTV controllers to use the new header location
- run clang-format on both files to keep ordering consistent

## Testing
- clang-format -style=file -i custom/integration/media_controller.cpp custom/integration/cctv_controller.cpp
- idf.py build *(fails: idf.py not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd83644fe08324b9a1488dde868e09