### PR TITLE
build(tab5): declare component dependencies

### DIFF
--- a/platforms/tab5/main/CMakeLists.txt
+++ b/platforms/tab5/main/CMakeLists.txt
@@ -18,9 +18,12 @@ file(GLOB_RECURSE MY_HAL_SRCS
     ./hal/*.cpp
 )
 
-idf_component_register(SRCS "app_main.cpp" ${APP_LAYER_SRCS} ${MY_HAL_SRCS}
-                    INCLUDE_DIRS "." ${APP_LAYER_INCS}
-                    EMBED_TXTFILES "../audio/canon_in_d.mp3" "../audio/startup_sfx.mp3" "../audio/shutdown_sfx.mp3")
+idf_component_register(
+    SRCS "app_main.cpp" ${APP_LAYER_SRCS} ${MY_HAL_SRCS}
+    INCLUDE_DIRS "." ${APP_LAYER_INCS}
+    REQUIRES core backup_server connection_tester diag net_sntp ota_update settings_core
+             settings_ui
+    EMBED_TXTFILES "../audio/canon_in_d.mp3" "../audio/startup_sfx.mp3" "../audio/shutdown_sfx.mp3")
 
 set(CUSTOM_ASSETS_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../custom/assets")
 get_filename_component(CUSTOM_ASSETS_DIR "${CUSTOM_ASSETS_DIR}" REALPATH)


### PR DESCRIPTION
## Summary
- add the tab5 app component dependencies so their public headers are on the include path

## Testing
- idf.py build *(fails: `idf.py`: command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd83670c508324b90e50ea126f808c