### PR TITLE
fix(integration): cast rounded value for snprintf

### DIFF
--- a/custom/integration/weather_formatter.cpp
+++ b/custom/integration/weather_formatter.cpp
@@ -190,7 +190,8 @@ namespace
         if (unit.empty())
         {
             char buffer[WEATHER_FORMATTER_MAX_VALUE_LEN];
-            std::snprintf(buffer, sizeof(buffer), "%d", round_temperature(converted));
+            std::snprintf(
+                buffer, sizeof(buffer), "%d", static_cast<int>(round_temperature(converted)));
             return std::string(buffer);
         }
 


### PR DESCRIPTION
## Summary
- cast the result of `round_temperature` before using `%d` in the sensor formatter

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8378d01c8324895f5d1dc080fd95