### PR TITLE
fix: ensure tab5 extra components path is registered

### DIFF
--- a/platforms/tab5/CMakeLists.txt
+++ b/platforms/tab5/CMakeLists.txt
@@ -4,11 +4,11 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-
 set(EXTRA_COMPONENT_DIRS
     "../../dependencies"
     "../../components"
 )
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
 project(m5stack_tab5)


### PR DESCRIPTION
## Summary
- set `EXTRA_COMPONENT_DIRS` before including the ESP-IDF project boilerplate so the Tab5 build can find user components

## Testing
- Unable to run `idf.py build` (idf.py is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd93e17690832482813313c405e2c7