### PR TITLE
fix(tab5): resolve extra component dirs

### DIFF
--- a/platforms/tab5/CMakeLists.txt
+++ b/platforms/tab5/CMakeLists.txt
@@ -4,10 +4,20 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-set(EXTRA_COMPONENT_DIRS
-    "../../dependencies"
-    "../../components"
+set(_extra_component_dirs
+    "${CMAKE_CURRENT_LIST_DIR}/../../dependencies"
+    "${CMAKE_CURRENT_LIST_DIR}/../../components"
 )
+
+set(EXTRA_COMPONENT_DIRS "")
+foreach(_dir IN LISTS _extra_component_dirs)
+    get_filename_component(_resolved "${_dir}" REALPATH)
+    list(APPEND EXTRA_COMPONENT_DIRS "${_resolved}")
+endforeach()
+
+unset(_resolved)
+unset(_dir)
+unset(_extra_component_dirs)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 


### PR DESCRIPTION
## Summary
- resolve Tab5 extra component directories relative to the platform CMake file
- normalize each entry to an absolute path so ESP-IDF can discover dependencies reliably

## Testing
- `idf.py reconfigure` *(fails: command not found in container)*
- `idf.py build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cda5258c3c83249a1532d94cb583b4