### PR TITLE
fix(hal): include algorithm for clamp

### DIFF
--- a/platforms/desktop/hal/components/hal_audio.cpp
+++ b/platforms/desktop/hal/components/hal_audio.cpp
@@ -7,6 +7,7 @@
 #include "hal/hal.h"
 #include <cmath>
 #include <mooncake_log.h>
+#include <algorithm>
 #include <SDL2/SDL.h>
 #include <thread>
 #include <iostream>

--- a/platforms/desktop/hal/hal_desktop.cpp
+++ b/platforms/desktop/hal/hal_desktop.cpp
@@ -6,6 +6,7 @@
 #include "hal_desktop.h"
 #include <SDL2/SDL.h>
 #include <mooncake_log.h>
+#include <algorithm>
 #include <random>
 #include <filesystem>
 #include <thread>

--- a/platforms/tab5/main/hal/components/hal_audio.cpp
+++ b/platforms/tab5/main/hal/components/hal_audio.cpp
@@ -5,6 +5,7 @@
  */
 #include "hal/hal_esp32.h"
 #include <mooncake_log.h>
+#include <algorithm>
 #include <vector>
 #include <memory>
 #include <string.h>

--- a/platforms/tab5/main/hal/components/hal_usb.cpp
+++ b/platforms/tab5/main/hal/components/hal_usb.cpp
@@ -5,6 +5,7 @@
  */
 #include "hal/hal_esp32.h"
 #include <mooncake_log.h>
+#include <algorithm>
 #include <vector>
 #include <driver/gpio.h>
 #include <memory>

--- a/platforms/tab5/main/hal/hal_esp32.cpp
+++ b/platforms/tab5/main/hal/hal_esp32.cpp
@@ -7,6 +7,7 @@
 extern "C" {
 #include "utils/rx8130/rx8130.h"
 }
+#include <algorithm>
 #include <mooncake_log.h>
 #include <esp_timer.h>
 #include <freertos/FreeRTOS.h>


### PR DESCRIPTION
## Summary
- include `<algorithm>` in HAL sources that call `std::clamp` to satisfy builds on both Tab5 and desktop targets

## Testing
- IDF_PATH=/opt/esp-idf ../../scripts/idf.py build *(fails: /opt/esp-idf/tools/idf.py: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68cda526ae3c832484189a7d03d890dc