### PR TITLE
fix: add freertos includes for RS485 HAL

### DIFF
--- a/platforms/tab5/main/hal/components/hal_rs485.cpp
+++ b/platforms/tab5/main/hal/components/hal_rs485.cpp
@@ -3,13 +3,19 @@
  *
  * SPDX-License-Identifier: MIT
  */
-#include "hal/hal_esp32.h"
-#include <mooncake_log.h>
-#include <vector>
-#include <driver/gpio.h>
+#include <cstdlib>
+#include <cstring>
 #include <memory>
+#include <vector>
+
+#include <driver/gpio.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <mooncake_log.h>
+
 #include "driver/uart.h"
 #include "esp_log.h"
+#include "hal/hal_esp32.h"
 
 #define TAG "hal_rs485"
 


### PR DESCRIPTION
## Summary
- include the FreeRTOS headers and C runtime headers needed by the RS485 HAL so the FreeRTOS APIs and C helpers compile

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb03e94cc8324bad6a102525eea4f