### PR TITLE
fix: zero-init record buffers

### DIFF
--- a/platforms/tab5/main/hal/components/hal_audio.cpp
+++ b/platforms/tab5/main/hal/components/hal_audio.cpp
@@ -131,10 +131,10 @@ static void _rec_test_task(void* param)
 
     // Create buffers
     if (_rec_test_data.audio_buffer == nullptr) {
-        _rec_test_data.audio_buffer = new int16_t[audio_buffer_size](0);
+        _rec_test_data.audio_buffer = new int16_t[audio_buffer_size]();
     }
     if (_rec_test_data.read_buffer == nullptr) {
-        _rec_test_data.read_buffer = new int16_t[read_buffer_size](0);
+        _rec_test_data.read_buffer = new int16_t[read_buffer_size]();
     }
 
     const size_t sample_rate   = 48000;


### PR DESCRIPTION
## Summary
- replace non-standard value-initialization syntax when allocating record buffers
- ensure record and read buffers are zero-initialized using standard new[]

## Testing
- `idf.py build` *(fails: idf.py not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdbcf2427c83248e9397eceac8beae