### PR TITLE
fix: declare local components for build

### DIFF
--- a/platforms/tab5/main/idf_component.yml
+++ b/platforms/tab5/main/idf_component.yml
@@ -8,3 +8,19 @@ dependencies:
   chmorgan/esp-file-iterator: 1.0.0
   espressif/led_strip: 3.0.0
   espressif/esp_lcd_ili9881c: ^1.0.1
+  core:
+    path: ../../../components/core
+  settings_core:
+    path: ../../../components/settings_core
+  settings_ui:
+    path: ../../../components/settings_ui
+  connection_tester:
+    path: ../../../components/connection_tester
+  net_sntp:
+    path: ../../../components/net_sntp
+  ota_update:
+    path: ../../../components/ota_update
+  diag:
+    path: ../../../components/diag
+  backup_server:
+    path: ../../../components/backup_server


### PR DESCRIPTION
## Summary
- declare each in-tree Tab5 component as a path dependency in the platform manifest so CMake can resolve them when using the IDF component manager

## Testing
- idf.py build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc03445108324b2f1a58f6faf254c