### PR TITLE
fix: align esp tls component requirements

### DIFF
--- a/components/connection_tester/CMakeLists.txt
+++ b/components/connection_tester/CMakeLists.txt
@@ -5,7 +5,7 @@ idf_component_register(
         "include"
     REQUIRES
         esp_http_client
-        esp_tls
+        esp-tls
         esp_wifi
         log
 )

--- a/components/ota_update/CMakeLists.txt
+++ b/components/ota_update/CMakeLists.txt
@@ -7,7 +7,7 @@ idf_component_register(
         esp_https_ota
         esp_http_client
         app_update
-        esp_tls
+        esp-tls
         mbedtls
         esp_system
         log


### PR DESCRIPTION
## Summary
- replace the deprecated `esp_tls` requirement with `esp-tls` in the connection tester and OTA update component build files

## Testing
- ./scripts/idf.py -C platforms/tab5 reconfigure *(fails: component manager could not resolve local dependency `backup_server`)*
- ./scripts/idf.py -C platforms/tab5 build *(fails: component manager could not resolve local dependency `backup_server`)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc3ffebc083249854348cfe75c62f