### PR TITLE
fix(tab5): add hal esp-idf dependencies

### DIFF
--- a/platforms/tab5/main/CMakeLists.txt
+++ b/platforms/tab5/main/CMakeLists.txt
@@ -22,7 +22,8 @@ idf_component_register(
     SRCS "app_main.cpp" ${APP_LAYER_SRCS} ${MY_HAL_SRCS}
     INCLUDE_DIRS "." ${APP_LAYER_INCS}
     REQUIRES backup_server connection_tester diag net_sntp ota_update settings_core
-             settings_ui
+             settings_ui m5stack_tab5 esp_wifi esp_netif esp_event nvs_flash
+             esp_http_server
     EMBED_TXTFILES "../audio/canon_in_d.mp3" "../audio/startup_sfx.mp3" "../audio/shutdown_sfx.mp3")
 
 set(CUSTOM_ASSETS_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../custom/assets")


### PR DESCRIPTION
## Summary
- add the ESP-IDF libraries used by the Tab5 HAL to the REQUIRES list in the platform CMake file so the component links against its dependencies

## Testing
- idf.py build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdce36ae248324848090815295c6ba