### PR TITLE
fix(tab5): include sys time header

### DIFF
--- a/platforms/tab5/main/hal/hal_esp32.cpp
+++ b/platforms/tab5/main/hal/hal_esp32.cpp
@@ -9,6 +9,7 @@ extern "C" {
 }
 #include <algorithm>
 #include <initializer_list>
+#include <sys/time.h>
 #include <mooncake_log.h>
 #include <esp_timer.h>
 #include <freertos/FreeRTOS.h>


### PR DESCRIPTION
## Summary
- include <sys/time.h> in the Tab5 HAL so timeval and settimeofday declarations are available

## Testing
- `idf.py build` *(fails: command not found in container image)*

------
https://chatgpt.com/codex/tasks/task_e_68cdce3e667c8324be9ffc40e957eb09