### PR TITLE
fix(settings_core): include nvs header

### DIFF
--- a/components/settings_core/src/app_cfg.c
+++ b/components/settings_core/src/app_cfg.c
@@ -3,9 +3,10 @@
  *
  * SPDX-License-Identifier: MIT
  */
-#include "settings_core/app_cfg.h"
-
 #include <string.h>
+#include <nvs.h>
+
+#include "settings_core/app_cfg.h"
 
 #ifndef ESP_STATIC_ASSERT
 #    define ESP_STATIC_ASSERT(CONDITION, MESSAGE) _Static_assert((CONDITION), #MESSAGE)


### PR DESCRIPTION
## Summary
- include the ESP-IDF NVS header in `app_cfg.c` so ESP_ERR_NVS_NOT_FOUND is declared before use

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cdcf57361883249137a9de69e1d728