### PR TITLE
fix(platform): adapt sntp and diag to idf 5.5

### DIFF
--- a/components/diag/src/diag.c
+++ b/components/diag/src/diag.c
@@ -5,6 +5,7 @@
  */
 #include "diag/diag.h"
 
+#include <inttypes.h>
 #include <stdio.h>
 
 #include "esp_err.h"
@@ -53,7 +54,7 @@ static esp_err_t health_handler(httpd_req_t* req)
     char    payload[128];
     int     written = snprintf(payload,
                            sizeof(payload),
-                           "{\"uptime_ms\":%lld,\"heap\":%u}",
+                           "{\"uptime_ms\":%lld,\"heap\":%" PRIu32 "}",
                            (long long)uptime_ms,
                            esp_get_free_heap_size());
     if (written < 0)
@@ -75,9 +76,7 @@ diag_start(const app_cfg_t* cfg, diag_handles_t* handles, diag_event_cb_t callba
     emit_diag_event(callback, user_data, DIAG_EVENT_STARTING, ESP_OK);
 
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
-    config.uri_match_fn   = httpd_uri_match_simple;
-
-    esp_err_t err = httpd_start(&handles->httpd, &config);
+    esp_err_t      err    = httpd_start(&handles->httpd, &config);
     if (err != ESP_OK)
     {
         ESP_LOGE(TAG, "Failed to start diagnostics server: 0x%x", (unsigned int)err);

--- a/components/net_sntp/src/net_sntp.c
+++ b/components/net_sntp/src/net_sntp.c
@@ -15,10 +15,11 @@ static const char* TAG = "net_sntp";
 
 esp_err_t net_sntp_start(const char* server, bool wait_for_sync)
 {
-    const char* servers[1] = {server ? server : "pool.ntp.org"};
+    const char* server_name = server ? server : "pool.ntp.org";
 
-    esp_sntp_config_t config = ESP_NETIF_SNTP_DEFAULT_CONFIG_MULTIPLE(servers);
-    config.sync_cb           = NULL;
+    esp_sntp_config_t config =
+        ESP_NETIF_SNTP_DEFAULT_CONFIG_MULTIPLE(1, ESP_SNTP_SERVER_LIST(server_name));
+    config.sync_cb = NULL;
 
     esp_err_t err = esp_netif_sntp_init(&config);
     if (err == ESP_ERR_INVALID_STATE)
@@ -54,6 +55,5 @@ esp_err_t net_sntp_start(const char* server, bool wait_for_sync)
 
 void net_sntp_stop(void)
 {
-    esp_netif_sntp_stop();
     esp_netif_sntp_deinit();
 }


### PR DESCRIPTION
## Summary
- update SNTP initialization to use the new ESP-IDF v5.5 multi-server macro and drop the removed stop call
- ensure diagnostics JSON formatting uses PRI macros and rely on default URI matcher now that httpd_uri_match_simple is internal

## Testing
- ⚠️ `idf.py build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd7f639f483248273bc50eccc561d