### PR TITLE
fix(tab5): add missing app requires

### DIFF
--- a/platforms/tab5/main/CMakeLists.txt
+++ b/platforms/tab5/main/CMakeLists.txt
@@ -23,7 +23,8 @@ idf_component_register(
     INCLUDE_DIRS "." ${APP_LAYER_INCS}
     REQUIRES backup_server connection_tester diag net_sntp ota_update settings_core
              settings_ui m5stack_tab5 esp_wifi esp_netif esp_event nvs_flash
-             esp_http_server
+             esp_http_server chmorgan__esp-audio-player mooncake mooncake_log
+             smooth_ui_toolkit power_monitor_ina226 esp_video imlib
     EMBED_TXTFILES "../audio/canon_in_d.mp3" "../audio/startup_sfx.mp3" "../audio/shutdown_sfx.mp3")
 
 set(CUSTOM_ASSETS_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../custom/assets")


### PR DESCRIPTION
## Summary
- add the mooncake, mooncake_log, smooth_ui_toolkit, power_monitor_ina226, esp_video, imlib, and esp-audio-player components to the Tab5 main app's dependency list so their headers are available during compilation

## Testing
- not run (ESP-IDF toolchain is unavailable in the provided environment)


------
https://chatgpt.com/codex/tasks/task_e_68cde09905ec8324964371e7d81b5641