### PR TITLE
fix: guard esp vfs fat include

### DIFF
--- a/custom/assets/asset_mount.c
+++ b/custom/assets/asset_mount.c
@@ -170,7 +170,13 @@ static void lv_fs_if_init(void)
 #include "driver/sdmmc_host.h"
 #include "esp_err.h"
 #include "esp_log.h"
+#if defined(__has_include)
+#if __has_include("esp_vfs_fat.h")
 #include "esp_vfs_fat.h"
+#endif
+#else
+#include "esp_vfs_fat.h"
+#endif
 #include "sdmmc_cmd.h"
 #endif
 


### PR DESCRIPTION
## Summary
- guard the esp_vfs_fat.h include in asset_mount.c so builds continue even when the header is unavailable

## Testing
- `idf.py build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce49fbca2c832498e757231ca2662d