### PR TITLE
fix(tab5): sanitize esp audio dependency

### DIFF
--- a/platforms/tab5/main/CMakeLists.txt
+++ b/platforms/tab5/main/CMakeLists.txt
@@ -23,7 +23,7 @@ idf_component_register(
     INCLUDE_DIRS "." ${APP_LAYER_INCS}
     REQUIRES backup_server connection_tester diag net_sntp ota_update settings_core
              settings_ui m5stack_tab5 esp_wifi esp_netif esp_event nvs_flash
-             esp_http_server chmorgan__esp-audio-player mooncake mooncake_log
+            esp_http_server chmorgan__esp_audio_player mooncake mooncake_log
              smooth_ui_toolkit power_monitor_ina226 esp_video imlib
     EMBED_TXTFILES "../audio/canon_in_d.mp3" "../audio/startup_sfx.mp3" "../audio/shutdown_sfx.mp3")
 


### PR DESCRIPTION
## Summary
- replace the Tab5 main app's esp-audio-player dependency with the sanitized esp_audio_player identifier so ESP-IDF resolves the component

## Testing
- not run (ESP-IDF toolchain unavailable in the provided environment)

------
https://chatgpt.com/codex/tasks/task_e_68ce49ca928883248099a855b1ab5159