### PR TITLE
Add cJSON dependency to Tab5 platform

### DIFF
--- a/platforms/tab5/main/CMakeLists.txt
+++ b/platforms/tab5/main/CMakeLists.txt
@@ -24,7 +24,7 @@ idf_component_register(
     REQUIRES backup_server connection_tester diag net_sntp ota_update settings_core
              settings_ui m5stack_tab5 esp_wifi esp_netif esp_event nvs_flash
              esp_http_server chmorgan__esp-audio-player mooncake mooncake_log
-             smooth_ui_toolkit power_monitor_ina226 esp_video imlib
+             smooth_ui_toolkit power_monitor_ina226 esp_video imlib cjson
     EMBED_TXTFILES "../audio/canon_in_d.mp3" "../audio/startup_sfx.mp3" "../audio/shutdown_sfx.mp3")
 
 set(CUSTOM_ASSETS_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../custom/assets")

--- a/platforms/tab5/main/idf_component.yml
+++ b/platforms/tab5/main/idf_component.yml
@@ -8,6 +8,7 @@ dependencies:
   chmorgan/esp-file-iterator: 1.0.0
   espressif/led_strip: 3.0.0
   espressif/esp_lcd_ili9881c: ^1.0.1
+  cjson: '*'
   settings_core:
     path: ../../../components/settings_core
   settings_ui:


### PR DESCRIPTION
## Summary
- add the cjson component requirement to the Tab5 platform's build manifest
- register the cjson dependency in the component's CMake definition so it links during builds

## Testing
- `idf.py build` *(fails: command not found: idf.py in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4d69e7dc8324b467e13f9ed471bc