### PR TITLE
fix: reference ESP-IDF cJSON component by namespace

### DIFF
--- a/platforms/tab5/main/idf_component.yml
+++ b/platforms/tab5/main/idf_component.yml
@@ -8,7 +8,7 @@ dependencies:
   chmorgan/esp-file-iterator: 1.0.0
   espressif/led_strip: 3.0.0
   espressif/esp_lcd_ili9881c: ^1.0.1
-  cjson: '*'
+  espressif/cjson: '*'
   settings_core:
     path: ../../../components/settings_core
   settings_ui:


### PR DESCRIPTION
## Summary
- update the Tab5 platform manifest to request the espressif/cjson component explicitly

## Testing
- `idf.py build` *(fails: `idf.py` is not available in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5053c1088324a455953f4ceddb41