### PR TITLE
ci: target esp32p4 on ESP-IDF 5.4.2 in CI workflows

### DIFF
--- a/.github/workflows/idf-build.yml
+++ b/.github/workflows/idf-build.yml
@@ -32,10 +32,12 @@ jobs:
             ccache-${{ runner.os }}-${{ github.ref_name }}-
             ccache-${{ runner.os }}-
 
-      - name: Build with ESP-IDF 5.5.x (esp32p4)
+      - name: Build with ESP-IDF 5.4.x (esp32p4)
         uses: espressif/esp-idf-ci-action@v1
+        env:
+          IDF_TARGET: esp32p4
         with:
-          esp_idf_version: v5.5.1
+          esp_idf_version: v5.4.2
           target: esp32p4
           path: platforms/tab5
           # mount ccache dir inside the container

--- a/.github/workflows/webflash.yml
+++ b/.github/workflows/webflash.yml
@@ -38,10 +38,12 @@ jobs:
             ccache-${{ runner.os }}-${{ github.ref_name }}-
             ccache-${{ runner.os }}-
 
-      - name: Build firmware (ESP-IDF 5.5.x / esp32p4)
+      - name: Build firmware (ESP-IDF 5.4.x / esp32p4)
         uses: espressif/esp-idf-ci-action@v1
+        env:
+          IDF_TARGET: esp32p4
         with:
-          esp_idf_version: v5.5.1
+          esp_idf_version: v5.4.2
           target: esp32p4
           path: .
           extra_docker_args: "-v ${{ github.workspace }}/.ccache:/root/.ccache -e CCACHE_DIR=/root/.ccache"


### PR DESCRIPTION
## Summary
- pin the IDF build workflow to ESP-IDF v5.4.2 and export IDF_TARGET for esp32p4
- update the webflash workflow to match the ESP-IDF v5.4.2 toolchain and target configuration

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ce5a3181e88324b3576d5332dd1f6f