### PR TITLE
Add golden update helper script

### DIFF
--- a/scripts/update_goldens.sh
+++ b/scripts/update_goldens.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export UPDATE_GOLDEN=1
+ctest --output-on-failure


### PR DESCRIPTION
## Summary
- add a script to export `UPDATE_GOLDEN=1` and run `ctest --output-on-failure`

## Testing
- not run (not needed for script addition)


------
https://chatgpt.com/codex/tasks/task_e_68ce5d926b788324aaad31851d6b20eb