### PR TITLE
fix: use json component for tab5 main

### DIFF
--- a/platforms/tab5/main/CMakeLists.txt
+++ b/platforms/tab5/main/CMakeLists.txt
@@ -24,7 +24,7 @@ idf_component_register(
     REQUIRES backup_server connection_tester diag net_sntp ota_update settings_core
              settings_ui m5stack_tab5 esp_wifi esp_netif esp_event nvs_flash
              esp_http_server chmorgan__esp-audio-player mooncake mooncake_log
-             smooth_ui_toolkit power_monitor_ina226 esp_video imlib cjson
+             smooth_ui_toolkit power_monitor_ina226 esp_video imlib json
     EMBED_TXTFILES "../audio/canon_in_d.mp3" "../audio/startup_sfx.mp3" "../audio/shutdown_sfx.mp3")
 
 set(CUSTOM_ASSETS_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../custom/assets")


### PR DESCRIPTION
## Summary
- switch the Tab5 main component dependency from cJSON to json so ESP-IDF resolves the built-in component

## Testing
- idf.py set-target esp32p4 *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5d668010832495d82e23386ea2d3