### PR TITLE
ci: log golden assets before host tests

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Build rooms_page_test
         run: cmake --build tests/build --target rooms_page_test -j
 
+      - name: List golden assets
+        run: ls -la tests/ui/golden
+
       - name: Run tests
         run: ctest --test-dir tests/build --output-on-failure --timeout 60
 


### PR DESCRIPTION
## Summary
- ensure the host-tests workflow lists the golden assets before executing the test suite

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68ce5da4654083248d47e2db7bc117a3