### PR TITLE
fix: use idf alias for esp-idf dependency

### DIFF
--- a/components/backup_server/idf_component.yml
+++ b/components/backup_server/idf_component.yml
@@ -3,5 +3,5 @@ description: Backup export HTTP server for device settings.
 targets:
   - esp32p4
 dependencies:
-  esp-idf: "~5.4"
+  idf: "~5.4"
   settings_core: "^0.1.0"

--- a/components/connection_tester/idf_component.yml
+++ b/components/connection_tester/idf_component.yml
@@ -3,4 +3,4 @@ description: Connectivity test utilities for network diagnostics.
 targets:
   - esp32p4
 dependencies:
-  esp-idf: "~5.4"
+  idf: "~5.4"

--- a/components/diag/idf_component.yml
+++ b/components/diag/idf_component.yml
@@ -3,6 +3,6 @@ description: Diagnostic HTTP endpoints and telemetry helpers.
 targets:
   - esp32p4
 dependencies:
-  esp-idf: "~5.4"
+  idf: "~5.4"
   settings_core: "^0.1.0"
   espressif/mdns: "^1.8.0"

--- a/components/net_sntp/idf_component.yml
+++ b/components/net_sntp/idf_component.yml
@@ -3,4 +3,4 @@ description: SNTP client wrapper for maintaining network time.
 targets:
   - esp32p4
 dependencies:
-  esp-idf: "~5.4"
+  idf: "~5.4"

--- a/components/ota_update/idf_component.yml
+++ b/components/ota_update/idf_component.yml
@@ -3,4 +3,4 @@ description: Helpers for performing OTA firmware updates.
 targets:
   - esp32p4
 dependencies:
-  esp-idf: "~5.4"
+  idf: "~5.4"

--- a/components/settings_core/idf_component.yml
+++ b/components/settings_core/idf_component.yml
@@ -3,4 +3,4 @@ description: Persistent application configuration helpers.
 targets:
   - esp32p4
 dependencies:
-  esp-idf: "~5.4"
+  idf: "~5.4"

--- a/components/settings_ui/idf_component.yml
+++ b/components/settings_ui/idf_component.yml
@@ -3,5 +3,5 @@ description: UI for configuring application settings.
 targets:
   - esp32p4
 dependencies:
-  esp-idf: "~5.4"
+  idf: "~5.4"
   settings_core: "^0.1.0"

--- a/platforms/tab5/main/idf_component.yml
+++ b/platforms/tab5/main/idf_component.yml
@@ -1,7 +1,7 @@
 ## IDF Component Manager Manifest File
 dependencies:
   ## Required IDF version
-  esp-idf: "~5.4"
+  idf: "~5.4"
   espressif/esp_hosted: 1.4.0
   espressif/esp_wifi_remote: 0.8.5
   chmorgan/esp-audio-player: 1.0.7


### PR DESCRIPTION
## Summary
- use the canonical `idf` alias for the esp-idf dependency in the Tab5 app manifest and shared components so the component resolver no longer searches for a non-existent `espressif/esp-idf`

## Testing
- idf.py build *(fails: `idf.py` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6f31022c83248e0391f7b8e0378c