### PR TITLE
chore: fix cjson dependency case

### DIFF
--- a/platforms/tab5/main/idf_component.yml
+++ b/platforms/tab5/main/idf_component.yml
@@ -8,7 +8,7 @@ dependencies:
   chmorgan/esp-file-iterator: 1.0.0
   espressif/led_strip: 3.0.0
   espressif/esp_lcd_ili9881c: ^1.0.1
-  espressif/cjson: '*'
+  espressif/cJSON: '*'
   settings_core:
     path: ../../../components/settings_core
   settings_ui:


### PR DESCRIPTION
## Summary
- fix the cJSON manifest entry for the Tab5 main component so the dependency name matches the registry casing

## Testing
- ./tools/install_idf.sh
- idf.py set-target esp32p4 *(fails: missing credentials for espressif/cJSON package)*
- idf.py build *(fails: missing credentials for espressif/cJSON package)*

------
https://chatgpt.com/codex/tasks/task_e_68ce733bf5088324a92ad370919d01de