### PR TITLE
Fix install script libusb guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Our custom data is in the following folders:
 - **ESP-IDF v5.4.2** (tested with the ESP32-P4 target)
 - **Python 3.8+** (for build scripts)
 - Toolchain installed per [Espressif instructions](https://docs.espressif.com/projects/esp-idf/en/latest/esp32p4/get-started/)
+- **libusb-1.0 runtime** (required by OpenOCD). On Debian/Ubuntu install via
+  `sudo apt-get install libusb-1.0-0`; on macOS use `brew install libusb`.
 
 > Tested with ESP-IDF v5.4.2 for esp32p4; newer releases may require additional fixes.
 

--- a/tools/install_idf.sh
+++ b/tools/install_idf.sh
@@ -16,6 +16,45 @@ for cmd in git python3 bash; do
   fi
 done
 
+check_libusb() {
+  python3 - <<'PY'
+import ctypes
+import sys
+
+NAMES = (
+    "libusb-1.0.so.0",
+    "libusb-1.0.dylib",
+    "libusb-1.0.dll",
+)
+
+for name in NAMES:
+    try:
+        ctypes.CDLL(name)
+    except OSError:
+        continue
+    else:
+        sys.exit(0)
+
+sys.exit(1)
+PY
+}
+
+if ! check_libusb; then
+  case "$(uname -s)" in
+    Linux)
+      echo "Error: libusb-1.0 runtime not found. Install it with 'sudo apt-get install libusb-1.0-0'" \
+        "or the equivalent package for your distribution." >&2
+      ;;
+    Darwin)
+      echo "Error: libusb runtime not found. Install it with 'brew install libusb'." >&2
+      ;;
+    *)
+      echo "Error: libusb runtime not found. Please install libusb-1.0 for your platform." >&2
+      ;;
+  esac
+  exit 1
+fi
+
 mkdir -p "${ESP_IDF_ROOT}"
 
 if [ -d "${IDF_PATH}" ] && [ ! -d "${IDF_PATH}/.git" ]; then


### PR DESCRIPTION
## Summary
- add a libusb runtime check to `tools/install_idf.sh` so the ESP-IDF toolchain install stops with actionable instructions instead of OpenOCD errors
- document the new libusb prerequisite in the root README for Linux and macOS hosts

## Testing
- idf.py build > build.log 2>&1
- npx --yes markdownlint-cli docs *(fails: existing lint violations in docs that predate this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9868a1ec8324a66b1cae47f05f93