### PR TITLE
fix(camera): include mutex header

### DIFF
--- a/platforms/tab5/main/hal/components/hal_camera.cpp
+++ b/platforms/tab5/main/hal/components/hal_camera.cpp
@@ -6,6 +6,7 @@
 #include <driver/gpio.h>
 #include <fcntl.h>
 #include <memory>
+#include <mutex>
 #include <mooncake_log.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
## Summary
- include <mutex> in the Tab5 camera HAL to match std::mutex usage

## Testing
- `idf.py build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf224863108324b105dc27669da4bd