### PR TITLE
fix: remove unused imlib include from hal camera

### DIFF
--- a/platforms/tab5/main/hal/components/hal_camera.cpp
+++ b/platforms/tab5/main/hal/components/hal_camera.cpp
@@ -31,7 +31,6 @@
 #include "freertos/queue.h"
 #include "freertos/task.h"
 #include "hal/hal_esp32.h"
-#include "imlib.h"
 #include "linux/videodev2.h"
 
 #define CAMERA_WIDTH  1280


### PR DESCRIPTION
## Summary
- remove the stale imlib include from the Tab5 camera HAL implementation

## Testing
- `idf.py build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2241b8a48324b16d23aab7d0e4c3