### PR TITLE
Fix camera cleanup to free img_show_data pointer

### DIFF
--- a/platforms/tab5/main/hal/components/hal_camera.cpp
+++ b/platforms/tab5/main/hal/components/hal_camera.cpp
@@ -296,8 +296,8 @@ void app_camera_display(void* arg)
     constexpr uint32_t kRgb565BytesPerPixel = 2;
     uint32_t           img_show_size        = screen_width * screen_height * kRgb565BytesPerPixel;
     // uint32_t img_offset = 280 * 720 * 2;
-        heap_caps_free(img_show);
-        img_show = NULL;
+    heap_caps_free(img_show_data);
+    img_show_data = NULL;
     }
     // close(camera->fd);
 


### PR DESCRIPTION
## Summary
- update the Tab5 camera cleanup path to free the allocated buffer via the existing `img_show_data` pointer

## Testing
- clang-format -style=file -lines=296:300 -i platforms/tab5/main/hal/components/hal_camera.cpp
- idf.py build *(fails: command not found in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf22592338832491e10f541115eecf