### PR TITLE
Add preflight automation for Tab5 builds

### DIFF
--- a/.github/workflows/idf-preflight.yml
+++ b/.github/workflows/idf-preflight.yml
@@ -1,0 +1,47 @@
+name: IDF Preflight (esp32p4)
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Install Python deps (pytest-embedded optional; enables on-target tests when HW is present)
+      - name: Python setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pyserial pytest pytest-embedded pytest-embedded-idf
+        shell: bash
+
+      # Install ESP-IDF using official action (respects Linux runners)
+      - name: Install ESP-IDF
+        uses: espressif/install-esp-idf-action@v1
+        with:
+          version: latest
+      # Alternatively, to match your repo script exactly, source your installer:
+      # - run: bash tools/install_idf.sh
+
+      - name: Preflight
+        shell: bash
+        run: |
+          bash scripts/preflight.sh
+
+      # Upload build artifacts & logs for debugging
+      - name: Archive build
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tab5-build
+          path: |
+            platforms/tab5/build/**
+            **/build/tests/**
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Run these from the repository root unless noted otherwise.
 | --- | --- | --- |
 | `idf.py set-target esp32p4` | First build in a fresh checkout | Only needed once per workspace unless you clean the build folder.
 | `idf.py build` | Every PR | Must succeed; catches most integration issues.
+| `bash scripts/preflight.sh` | Before requesting review | Runs repo installer, fetches deps, builds Tab5, runs tests, and checks for boot loops when SERIAL_PORT is set. |
 | `idf.py clang-format` <br>or `clang-format -style=file -i <files>` | Whenever C/C++ is touched | Uses the repo's `.clang-format` (clang-format 13). Stage formatted files.
 | `idf.py lint` | When modifying components or build metadata | Ensures `idf_component.yml` metadata stays valid; safe to run even if no changes were made.
 | `ctags -R` / IDE index refresh | Optional but recommended | Keeps symbol navigation accurate after large refactors.

--- a/ai/tasks/00_preflight_build_and_bootloop_guard.md
+++ b/ai/tasks/00_preflight_build_and_bootloop_guard.md
@@ -1,0 +1,310 @@
+# Task: Preflight build, tests, and boot-loop guard for M5Tab5-UserDemo
+
+## Objective
+When Codex (or any contributor) proposes code:
+1) Use repo tools (esp. `tools/install_idf.sh`) to prepare ESP-IDF.
+2) Build exactly like the maintainer does.
+3) Run host/unit tests in `tests/` and fail if any test fails.
+4) If a serial port is available, run a boot-loop guard immediately after flashing on a local/dev machine (CI step is optional unless a hardware runner is present).
+5) Only open PRs that **pass preflight**.
+
+## Canonical local build sequence (MUST be followed)
+```bash
+git clone https://github.com/baba-dev/M5Tab5-UserDemo
+cd M5Tab5-UserDemo
+
+# Install / activate IDF via our repo tool (no ad-hoc installers)
+bash tools/install_idf.sh          # sets/exports IDF env for this shell
+
+# Fetch external deps (must succeed)
+python ./fetch_repos.py
+
+# Build for Tab5
+cd platforms/tab5
+idf.py set-target esp32p4
+idf.py build
+```
+
+Use idf.py set-target esp32p4 (this clears & regenerates sdkconfig as per IDF docs). 
+Espressif Systems
+
+Don’t invent alternative flows or other actions to “speed up”; this path is authoritative. The M5Stack Tab5 user demo guide also shows the same platforms/tab5 layout and fetch_repos.py. 
+M5Stack Docs
+
+Tests (MUST PASS)
+
+Run component/unit tests (Unity) discovered under tests/ or component test/ folders. Unity test layout is the official way for ESP-IDF. 
+Espressif Systems
+
+If a host CMake test project exists, build it and run ctest with --output-on-failure.
+
+On hardware test rigs (optional), use pytest-embedded to drive simple on-target checks. 
+Espressif Systems
++1
+
+Boot-loop guard (MUST if serial available; optional in CI)
+
+After flashing on a developer machine, run scripts/bootloop_guard.py with --port <PORT> for 30–45s.
+
+Fail if monitor shows repeating reset banners/panics (e.g., rst:, panic, abort, watchdog), or >3 resets in the window. Panic/cores are standard IDF behaviors. 
+Espressif Systems
++2
+Espressif Systems
++2
+
+Acceptance criteria (PRs that Codex proposes MUST meet all)
+
+Builds with idf.py set-target esp32p4 && idf.py build under platforms/tab5 with the IDF env from tools/install_idf.sh. 
+Espressif Systems
+
+python ./fetch_repos.py completes without errors (deps present).
+
+./scripts/preflight.sh exits 0 locally; CI job idf-preflight is green.
+
+If SERIAL_PORT is set or --port provided, bootloop_guard.py reports NO_BOOTLOOP.
+
+All tests in tests/ (and component test/) pass (Unity/pytest). 
+Espressif Systems
++1
+
+Notes
+
+Use IDF monitor semantics and patterns for parsing the serial stream (we rely on standard IDF monitor output). 
+Espressif Systems
+
+Do not downgrade/replace IDF. Use our installer script and the IDF it selects.
+
+
+---
+
+# Add these helper files
+
+## 1) `scripts/preflight.sh` (bash)
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[preflight] Using repo installer to setup ESP-IDF..."
+bash tools/install_idf.sh
+
+echo "[preflight] Fetching external components..."
+python ./fetch_repos.py
+
+echo "[preflight] Building Tab5 app (esp32p4)..."
+pushd platforms/tab5 >/dev/null
+idf.py set-target esp32p4
+idf.py build
+popd >/dev/null
+
+echo "[preflight] Running host/unit tests if present..."
+if [ -f tests/CMakeLists.txt ]; then
+  cmake -S tests -B build/tests -DCMAKE_BUILD_TYPE=Debug
+  cmake --build build/tests -- -j
+  ctest --test-dir build/tests --output-on-failure
+fi
+
+# Component Unity tests via IDF (if any component has test/ with Unity cases)
+if grep -R --include="CMakeLists.txt" -n "idf_component_register" components >/dev/null 2>&1; then
+  echo "[preflight] Scanning for Unity tests in components/*/test ..."
+  # IDF standard: tests usually land in a dedicated test app; if one exists, build it.
+  # If you have a test app target (e.g., 'unit_test_app'), you can uncomment:
+  # pushd platforms/tab5 >/dev/null
+  # idf.py build -DIDF_UNIT_TESTING=1
+  # popd >/dev/null
+fi
+
+# Optional hardware boot-loop guard
+if [ "${SERIAL_PORT:-}" != "" ]; then
+  echo "[preflight] Serial port detected ($SERIAL_PORT); running boot-loop guard..."
+  python scripts/bootloop_guard.py --port "$SERIAL_PORT" --seconds 45 || {
+    echo "::error::Boot-loop or panic detected on device"
+    exit 1
+  }
+fi
+
+echo "[preflight] OK"
+```
+
+Why these choices?
+
+idf.py is the canonical front-end for build/flash/monitor. 
+Espressif Systems
+
+set-target explicitly selects esp32p4 and regenerates config as documented. 
+Espressif Systems
+
+## 2) scripts/bootloop_guard.py
+```
+#!/usr/bin/env python3
+import argparse, sys, time, re
+try:
+    import serial
+except ImportError:
+    print("pyserial not installed. pip install pyserial", file=sys.stderr)
+    sys.exit(2)
+
+PATTERNS = [
+    re.compile(rb"rst:0x", re.I),
+    re.compile(rb"panic", re.I),
+    re.compile(rb"abort", re.I),
+    re.compile(rb"Guru Meditation", re.I),  # legacy wording still appears on some targets
+    re.compile(rb"watchdog", re.I),
+]
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", required=True, help="Serial port (e.g. COM5 or /dev/ttyACM0)")
+    ap.add_argument("--baud", type=int, default=115200)
+    ap.add_argument("--seconds", type=int, default=30)
+    args = ap.parse_args()
+
+    resets = 0
+    start = time.time()
+
+    try:
+        with serial.Serial(args.port, args.baud, timeout=0.2) as ser:
+            ser.reset_input_buffer()
+            while time.time() - start < args.seconds:
+                data = ser.read(8192)
+                if not data:
+                    continue
+                sys.stdout.buffer.write(data)
+                sys.stdout.flush()
+                for pat in PATTERNS:
+                    if pat.search(data):
+                        if b"rst:" in data:
+                            resets += 1
+                        else:
+                            print("\n[bootloop_guard] panic/abort/watchdog matched -> FAIL", file=sys.stderr)
+                            return 1
+                if resets > 3:
+                    print("\n[bootloop_guard] too many resets -> FAIL", file=sys.stderr)
+                    return 1
+    except serial.SerialException as e:
+        print(f"[bootloop_guard] Serial error: {e}", file=sys.stderr)
+        return 2
+
+    print("\n[bootloop_guard] NO_BOOTLOOP", file=sys.stderr)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+This follows IDF monitor semantics (scan reset banner/panic strings). For reference: idf.py monitor behavior & fatal error/panic docs. 
+Espressif Systems
++1
+
+Make it executable:
+
+git update-index --add --chmod=+x scripts/preflight.sh
+
+CI that enforces the same thing
+
+Path: .github/workflows/idf-preflight.yml
+
+```
+name: IDF Preflight (esp32p4)
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Install Python deps (pytest-embedded optional; enables on-target tests when HW is present)
+      - name: Python setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pyserial pytest pytest-embedded pytest-embedded-idf
+        shell: bash
+
+      # Install ESP-IDF using official action (respects Linux runners)
+      - name: Install ESP-IDF
+        uses: espressif/install-esp-idf-action@v1
+        with:
+          version: latest
+      # Alternatively, to match your repo script exactly, source your installer:
+      # - run: bash tools/install_idf.sh
+
+      - name: Preflight
+        shell: bash
+        run: |
+          bash scripts/preflight.sh
+
+      # Upload build artifacts & logs for debugging
+      - name: Archive build
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tab5-build
+          path: |
+            platforms/tab5/build/**
+            **/build/tests/**
+          if-no-files-found: ignore
+```
+
+Uses Espressif’s official IDF setup/CI actions — they wrap the official IDF images/tools and are the recommended way to build in GitHub Actions. 
+GitHub
++2
+GitHub
++2
+
+Your preflight script runs the same sequence as you do locally; that parity is the point.
+
+If you later add a self-hosted runner with the Tab5 attached, set SERIAL_PORT in runner env so the boot-loop guard runs automatically and gates the PR.
+
+Why this approach is solid
+
+Exact target selection & build: idf.py set-target esp32p4 is the supported way, and it (re)generates sdkconfig per target. 
+Espressif Systems
+
+Unity tests are first-class in IDF; placing tests in test/ with unity.h is canonical. 
+Espressif Systems
+
+Boot-loop detection: leveraging known monitor strings (resets, panics, watchdogs) mirrors idf.py monitor output and IDF’s panic handler behavior. 
+Espressif Systems
++1
+
+Repo-specific layout: Your Tab5 demo uses platforms/tab5 and fetch_repos.py, exactly what we enforce. 
+M5Stack Docs
+
+Optional (nice to have, later)
+
+On-target automated tests: Add a tiny pytest file under tests/embedded/ that flashes and asserts a boot banner + single UI tick using pytest-embedded-idf. This follows Espressif’s guidance for automated target testing. 
+Espressif Systems
+
+CI matrix for multiple IDF versions (e.g., v5.4.x, latest) using install-esp-idf-action. 
+GitHub
+
+Use esp-idf-ci-action if you prefer the Docker-wrapped builder. 
+GitHub
+
+What I created for you (summary)
+
+ai/tasks/00_preflight_build_and_bootloop_guard.md — the Codex-visible checklist (first file Codex will read).
+
+scripts/preflight.sh — single entry-point that replicates your local workflow, runs tests, and (optionally) boot-loop check.
+
+scripts/bootloop_guard.py — simple serial log scanner to catch resets/panics.
+
+.github/workflows/idf-preflight.yml — CI to enforce the preflight on every PR/push.
+
+If you want, I can also add a one-line pointer in docs/AI_GUIDELINES.md:
+
+“AI contributors must pass scripts/preflight.sh locally before opening PRs.”
+
+That’s it — from here, Codex has no excuse to ship untested, non-building changes. ✅

--- a/docs/AI_GUIDELINES.md
+++ b/docs/AI_GUIDELINES.md
@@ -31,6 +31,7 @@ safety rails, and formatting rules for automated contributions.
 
 - Run `idf.py build` before finalizing a change. Resolve compiler warnings
   rather than silencing them.
+- Run `bash scripts/preflight.sh` and ensure it exits 0 before opening a PR.
 - Execute `idf.py lint` when modifying integration metadata or component
   manifests.
 - Run `npx markdownlint docs` after editing Markdown. Fix or justify any

--- a/scripts/bootloop_guard.py
+++ b/scripts/bootloop_guard.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import argparse
+import re
+import sys
+import time
+
+try:
+    import serial
+except ImportError:
+    print("pyserial not installed. pip install pyserial", file=sys.stderr)
+    sys.exit(2)
+
+PATTERNS = [
+    re.compile(rb"rst:0x", re.I),
+    re.compile(rb"panic", re.I),
+    re.compile(rb"abort", re.I),
+    re.compile(rb"Guru Meditation", re.I),  # legacy wording still appears on some targets
+    re.compile(rb"watchdog", re.I),
+]
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", required=True, help="Serial port (e.g. COM5 or /dev/ttyACM0)")
+    ap.add_argument("--baud", type=int, default=115200)
+    ap.add_argument("--seconds", type=int, default=30)
+    args = ap.parse_args()
+
+    resets = 0
+    start = time.time()
+
+    try:
+        with serial.Serial(args.port, args.baud, timeout=0.2) as ser:
+            ser.reset_input_buffer()
+            while time.time() - start < args.seconds:
+                data = ser.read(8192)
+                if not data:
+                    continue
+                sys.stdout.buffer.write(data)
+                sys.stdout.flush()
+                for pat in PATTERNS:
+                    if pat.search(data):
+                        if b"rst:" in data:
+                            resets += 1
+                        else:
+                            print("\n[bootloop_guard] panic/abort/watchdog matched -> FAIL", file=sys.stderr)
+                            return 1
+                if resets > 3:
+                    print("\n[bootloop_guard] too many resets -> FAIL", file=sys.stderr)
+                    return 1
+    except serial.SerialException as exc:
+        print(f"[bootloop_guard] Serial error: {exc}", file=sys.stderr)
+        return 2
+
+    print("\n[bootloop_guard] NO_BOOTLOOP", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[preflight] Using repo installer to setup ESP-IDF..."
+bash tools/install_idf.sh
+
+echo "[preflight] Fetching external components..."
+python ./fetch_repos.py
+
+echo "[preflight] Building Tab5 app (esp32p4)..."
+pushd platforms/tab5 >/dev/null
+idf.py set-target esp32p4
+idf.py build
+popd >/dev/null
+
+echo "[preflight] Running host/unit tests if present..."
+if [ -f tests/CMakeLists.txt ]; then
+  cmake -S tests -B build/tests -DCMAKE_BUILD_TYPE=Debug
+  cmake --build build/tests -- -j
+  ctest --test-dir build/tests --output-on-failure
+fi
+
+# Component Unity tests via IDF (if any component has test/ with Unity cases)
+if grep -R --include="CMakeLists.txt" -n "idf_component_register" components >/dev/null 2>&1; then
+  echo "[preflight] Scanning for Unity tests in components/*/test ..."
+  # IDF standard: tests usually land in a dedicated test app; if one exists, build it.
+  # If you have a test app target (e.g., 'unit_test_app'), you can uncomment:
+  # pushd platforms/tab5 >/dev/null
+  # idf.py build -DIDF_UNIT_TESTING=1
+  # popd >/dev/null
+fi
+
+# Optional hardware boot-loop guard
+if [ "${SERIAL_PORT:-}" != "" ]; then
+  echo "[preflight] Serial port detected ($SERIAL_PORT); running boot-loop guard..."
+  python scripts/bootloop_guard.py --port "$SERIAL_PORT" --seconds 45 || {
+    echo "::error::Boot-loop or panic detected on device"
+    exit 1
+  }
+fi
+
+echo "[preflight] OK"


### PR DESCRIPTION
## Summary
- document a required preflight workflow for AI contributors and surface it in the main agent contract
- add a repo-level preflight script plus boot-loop guard helper referenced by new contributor guidance
- wire GitHub Actions IDF preflight workflow to run the same automation in CI

## Testing
- python -m compileall scripts/bootloop_guard.py

------
https://chatgpt.com/codex/tasks/task_e_68cf23f8f4ac832496701d6f07d02687