### PR TITLE
fix: replace launcher wallpaper with code-generated white fill

### DIFF
--- a/app/apps/app_launcher/view/view.cpp
+++ b/app/apps/app_launcher/view/view.cpp
@@ -6,7 +6,6 @@
 #include "view.h"
 
 #include <apps/utils/audio/audio.h>
-#include <assets/assets.h>
 #include <hal/hal.h>
 #include <lvgl.h>
 #include <mooncake_log.h>
@@ -38,12 +37,10 @@ void LauncherView::init()
     LvglLockGuard lock;
 
     // Base screen
-    lv_obj_remove_flag(lv_screen_active(), LV_OBJ_FLAG_SCROLLABLE);
-
-    // Background image
-    _img_bg = std::make_unique<Image>(lv_screen_active());
-    _img_bg->setAlign(LV_ALIGN_CENTER);
-    _img_bg->setSrc(&launcher_bg);
+    lv_obj_t* screen = lv_screen_active();
+    lv_obj_remove_flag(screen, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_style_bg_color(screen, lv_color_white(), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(screen, LV_OPA_COVER, LV_PART_MAIN);
 
     // Install panels
     _panels.push_back(std::make_unique<PanelRtc>());

--- a/app/apps/app_launcher/view/view.h
+++ b/app/apps/app_launcher/view/view.h
@@ -323,7 +323,6 @@ namespace launcher_view
 
     private:
         bool                                                     _is_stacked = false;
-        std::unique_ptr<smooth_ui_toolkit::lvgl_cpp::Image>      _img_bg;
         std::vector<std::unique_ptr<PanelBase>>                  _panels;
         ui_root_t*                                               _ui_root = nullptr;
         std::unique_ptr<custom::integration::SettingsController> _settings_controller;

--- a/custom/ui/ui_wallpaper.c
+++ b/custom/ui/ui_wallpaper.c
@@ -5,8 +5,6 @@
  */
 #include "ui_wallpaper.h"
 
-#include "assets/assets.h"
-
 ui_wallpaper_t* ui_wallpaper_attach(lv_obj_t* parent)
 {
     if (parent == NULL)
@@ -32,22 +30,9 @@ ui_wallpaper_t* ui_wallpaper_attach(lv_obj_t* parent)
     lv_obj_set_size(wallpaper->layer, LV_PCT(100), LV_PCT(100));
     lv_obj_add_flag(wallpaper->layer, LV_OBJ_FLAG_IGNORE_LAYOUT);
     lv_obj_move_background(wallpaper->layer);
-    lv_obj_set_style_bg_opa(wallpaper->layer, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(wallpaper->layer, lv_color_white(), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(wallpaper->layer, LV_OPA_COVER, LV_PART_MAIN);
     lv_obj_set_style_border_width(wallpaper->layer, 0, LV_PART_MAIN);
-
-    wallpaper->image = lv_image_create(wallpaper->layer);
-    if (wallpaper->image == NULL)
-    {
-        lv_obj_del(wallpaper->layer);
-        lv_free(wallpaper);
-        return NULL;
-    }
-
-    lv_obj_remove_style_all(wallpaper->image);
-    lv_image_set_src(wallpaper->image, &launcher_bg);
-    lv_obj_set_align(wallpaper->image, LV_ALIGN_CENTER);
-    lv_obj_add_flag(wallpaper->image, LV_OBJ_FLAG_IGNORE_LAYOUT);
-    lv_obj_move_background(wallpaper->image);
 
     return wallpaper;
 }
@@ -57,12 +42,6 @@ void ui_wallpaper_detach(ui_wallpaper_t* wallpaper)
     if (wallpaper == NULL)
     {
         return;
-    }
-
-    if (wallpaper->image != NULL)
-    {
-        lv_obj_del(wallpaper->image);
-        wallpaper->image = NULL;
     }
 
     if (wallpaper->layer != NULL)

--- a/custom/ui/ui_wallpaper.h
+++ b/custom/ui/ui_wallpaper.h
@@ -27,7 +27,6 @@ extern "C"
     typedef struct ui_wallpaper_t
     {
         lv_obj_t* layer;
-        lv_obj_t* image;
     } ui_wallpaper_t;
 
     ui_wallpaper_t* ui_wallpaper_attach(lv_obj_t* parent);


### PR DESCRIPTION
## Summary
- set the launcher screen background to a solid white fill generated in code
- update the shared wallpaper helper to render a white layer instead of loading the launcher image

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cf26b0f1d483249933c98b70357fae