### PR TITLE
chore: remove wallpaper png lookups

### DIFF
--- a/custom/assets/README.md
+++ b/custom/assets/README.md
@@ -6,7 +6,7 @@ firmware consumes at startup.
 
 | id | Source file | Mounted path |
 | --- | --- | --- |
-| *(example)* `bg_default` | `bg/default.png` | `/spiffs/custom/assets/bg/default.png` |
+| *(example)* `icon_play` | `icons/play.webp` | `/spiffs/custom/assets/icons/play.webp` |
 
 Add or update rows when you introduce new images or fonts so UI code can reference the
 correct mount paths. Keep the filenames stable; bots only touch generated outputs under

--- a/custom/assets/asset_mount.h
+++ b/custom/assets/asset_mount.h
@@ -10,8 +10,6 @@ extern "C" {
 #endif
 
 void assets_fs_init(void);
-const char *assets_path_1(void);
-const char *assets_path_2(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- drop the unused wallpaper asset lookup helpers that still pointed at PNG backgrounds
- generalize the asset README example to avoid referencing background PNGs
- update the filesystem init warning to describe generic asset loading instead of wallpapers

## Testing
- idf.py build *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d02d9324748324bd30274a9b564912