### PR TITLE
Fix Tab5 preflight for IDF 5.4.2 compatibility

### DIFF
--- a/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_v5.4.2/Kconfig.slave_select.in
+++ b/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_v5.4.2/Kconfig.slave_select.in
@@ -1,0 +1,1 @@
+source "../idf_v5.4/Kconfig.slave_select.in"

--- a/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_v5.4.2/Kconfig.soc_wifi_caps.in
+++ b/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_v5.4.2/Kconfig.soc_wifi_caps.in
@@ -1,0 +1,1 @@
+source "../idf_v5.4/Kconfig.soc_wifi_caps.in"

--- a/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_v5.4.2/Kconfig.wifi.in
+++ b/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_v5.4.2/Kconfig.wifi.in
@@ -1,0 +1,1 @@
+source "../idf_v5.4/Kconfig.wifi.in"

--- a/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_vv5.4.2/Kconfig.slave_select.in
+++ b/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_vv5.4.2/Kconfig.slave_select.in
@@ -1,0 +1,1 @@
+source "../idf_v5.4/Kconfig.slave_select.in"

--- a/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_vv5.4.2/Kconfig.soc_wifi_caps.in
+++ b/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_vv5.4.2/Kconfig.soc_wifi_caps.in
@@ -1,0 +1,1 @@
+source "../idf_v5.4/Kconfig.soc_wifi_caps.in"

--- a/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_vv5.4.2/Kconfig.wifi.in
+++ b/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_vv5.4.2/Kconfig.wifi.in
@@ -1,0 +1,1 @@
+source "../idf_v5.4/Kconfig.wifi.in"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -7,6 +7,19 @@ cd "$ROOT_DIR"
 echo "[preflight] Using repo installer to setup ESP-IDF..."
 bash tools/install_idf.sh
 
+# Ensure the ESP-IDF environment is active for the remainder of the script.
+ESP_IDF_VERSION=${ESP_IDF_VERSION:-v5.4.2}
+ESP_IDF_ROOT=${ESP_IDF_ROOT:-$HOME/.espressif}
+IDF_PATH="${ESP_IDF_ROOT}/esp-idf-${ESP_IDF_VERSION}"
+
+if [ ! -d "${IDF_PATH}" ]; then
+  echo "::error::Expected ESP-IDF at ${IDF_PATH}, but it was not found"
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "${IDF_PATH}/export.sh"
+
 echo "[preflight] Fetching external components..."
 python ./fetch_repos.py
 


### PR DESCRIPTION
## Summary
- add passthrough Kconfig directories for IDF v5.4.2 with and without the v prefix so wifi remote loads the existing 5.4 rules
- source the installed ESP-IDF environment inside preflight so idf.py stays on PATH for the build step

## Testing
- ESP_IDF_VERSION=v5.4.2 bash scripts/preflight.sh

------
https://chatgpt.com/codex/tasks/task_e_68d06712dbfc83249708b5e616505f32