### PR TITLE
fix: remove stale wifi remote override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dependencies
 custom/assets/bg/*.c
 custom/assets/bg/*.h
 tests/ui/output/
+platforms/*/managed_components/

--- a/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_v5.4.2/Kconfig.slave_select.in
+++ b/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_v5.4.2/Kconfig.slave_select.in
@@ -1,1 +1,0 @@
-source "../idf_v5.4/Kconfig.slave_select.in"

--- a/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_v5.4.2/Kconfig.soc_wifi_caps.in
+++ b/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_v5.4.2/Kconfig.soc_wifi_caps.in
@@ -1,1 +1,0 @@
-source "../idf_v5.4/Kconfig.soc_wifi_caps.in"

--- a/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_v5.4.2/Kconfig.wifi.in
+++ b/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_v5.4.2/Kconfig.wifi.in
@@ -1,1 +1,0 @@
-source "../idf_v5.4/Kconfig.wifi.in"

--- a/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_vv5.4.2/Kconfig.slave_select.in
+++ b/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_vv5.4.2/Kconfig.slave_select.in
@@ -1,1 +1,0 @@
-source "../idf_v5.4/Kconfig.slave_select.in"

--- a/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_vv5.4.2/Kconfig.soc_wifi_caps.in
+++ b/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_vv5.4.2/Kconfig.soc_wifi_caps.in
@@ -1,1 +1,0 @@
-source "../idf_v5.4/Kconfig.soc_wifi_caps.in"

--- a/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_vv5.4.2/Kconfig.wifi.in
+++ b/platforms/tab5/managed_components/espressif__esp_wifi_remote/idf_vv5.4.2/Kconfig.wifi.in
@@ -1,1 +1,0 @@
-source "../idf_v5.4/Kconfig.wifi.in"


### PR DESCRIPTION
## Summary
- remove the partial esp_wifi_remote component snapshot so the component manager can fetch the full archive
- ignore managed_components directories to prevent accidentally committing regenerated artifacts

## Testing
- not run (idf.py not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d0dca201748324812ac37fcaece372