### PR TITLE
fix(platforms): guard optional wifi hosted deps

### DIFF
--- a/custom/integration/settings_controller.cpp
+++ b/custom/integration/settings_controller.cpp
@@ -907,7 +907,7 @@ namespace custom::integration
 
     void SettingsController::Impl::test_wifi_connection()
     {
-#if defined(ESP_PLATFORM)
+#if defined(ESP_PLATFORM) && CONFIG_APP_ENABLE_WIFI_HOSTED
         wifi_ap_record_t ap_info{};
         esp_err_t        err = esp_wifi_sta_get_ap_info(&ap_info);
         if (err == ESP_OK)
@@ -923,6 +923,8 @@ namespace custom::integration
         {
             post_connection_result("wifi", UI_PAGE_SETTINGS_STATUS_UNKNOWN, "Unavailable");
         }
+#elif defined(ESP_PLATFORM)
+        post_connection_result("wifi", UI_PAGE_SETTINGS_STATUS_UNKNOWN, "ESP-Hosted disabled");
 #else
         post_connection_result("wifi", UI_PAGE_SETTINGS_STATUS_WARNING, "Not supported on host");
 #endif

--- a/platforms/tab5/dependencies.lock
+++ b/platforms/tab5/dependencies.lock
@@ -126,7 +126,7 @@ dependencies:
       registry_url: https://components.espressif.com/
       type: service
     rules:
-    - if: CONFIG_APP_ENABLE_WIFI_HOSTED
+    - if: $CONFIG{CONFIG_APP_ENABLE_WIFI_HOSTED} == y
     version: 1.4.0
   espressif/esp_lcd_ili9881c:
     component_hash: eb9ba0484d1d14171b69e5d192716fb1cdd6ef068aa4014dc3202486e124498e
@@ -228,7 +228,7 @@ dependencies:
       registry_url: https://components.espressif.com/
       type: service
     rules:
-    - if: CONFIG_APP_ENABLE_WIFI_HOSTED
+    - if: $CONFIG{CONFIG_APP_ENABLE_WIFI_HOSTED} == y
     version: 0.8.5
   espressif/led_strip:
     component_hash: f907c58f722c58ab8545366668cfd8769cefb7d97a631a14e9d16234cc72bdff

--- a/platforms/tab5/main/idf_component.yml
+++ b/platforms/tab5/main/idf_component.yml
@@ -5,11 +5,11 @@ dependencies:
   espressif/esp_hosted:
     version: 1.4.0
     rules:
-      - if: "CONFIG_APP_ENABLE_WIFI_HOSTED"
+      - if: "$CONFIG{CONFIG_APP_ENABLE_WIFI_HOSTED} == y"
   espressif/esp_wifi_remote:
     version: 0.8.5
     rules:
-      - if: "CONFIG_APP_ENABLE_WIFI_HOSTED"
+      - if: "$CONFIG{CONFIG_APP_ENABLE_WIFI_HOSTED} == y"
   chmorgan/esp-audio-player: 1.0.7
   chmorgan/esp-file-iterator: 1.0.0
   espressif/led_strip: 3.0.0


### PR DESCRIPTION
## Summary
- fix the optional dependency rules for esp_hosted and esp_wifi_remote to use a valid Kconfig expression
- skip Wi-Fi hosted specific logic when the feature is disabled so the app links cleanly

## Testing
- idf.py build

------
https://chatgpt.com/codex/tasks/task_e_68d138309654832490e5acca2de834e4