### PR TITLE
fix: clean wifi remote dependencies

### DIFF
--- a/.github/workflows/idf-build-and-webflash.yml
+++ b/.github/workflows/idf-build-and-webflash.yml
@@ -41,7 +41,15 @@ jobs:
           esp_idf_version: v5.4.2
           target: esp32p4
           path: platforms/tab5
-          command: idf.py build
+          command: |
+            set -euo pipefail
+            if grep -R "espressif/settings_core" -n .; then
+              echo "Do not reference espressif/settings_core"
+              exit 1
+            fi
+            rm -rf managed_components
+            idf.py reconfigure
+            idf.py build
 
       - name: Merge firmware for ESP Web Tools
         shell: bash

--- a/platforms/tab5/main/Kconfig.projbuild
+++ b/platforms/tab5/main/Kconfig.projbuild
@@ -1,4 +1,4 @@
-menu "Tab5 application"
+menu "Project Options"
 
 config APP_LOG_LEVEL
     int "Default application log level"
@@ -11,14 +11,10 @@ config APP_LOG_LEVEL
 menu "App Features"
 
 config APP_ENABLE_WIFI_HOSTED
-    bool "Enable ESP-Hosted (Wi-Fi over SDIO) on Tab5"
-    default n
+    bool "Enable Wi-Fi over ESP-Hosted"
+    default y
     help
-      When enabled, the firmware will power on the ESP-Hosted SDIO coprocessor
-      and bring up the remote Wi-Fi stack. Disable this to keep SDIO idle while
-      other system issues are being debugged.
-
-endmenu
+      Build the app with remote Wi-Fi (ESP-Hosted/esp_wifi_remote) enabled.
 
 config HAL_AUDIO_ENABLE_LONG_DEMO
     bool "Enable long Canon in D demo"
@@ -27,5 +23,7 @@ config HAL_AUDIO_ENABLE_LONG_DEMO
       Enable this option to embed the long-form Canon in D MP3 demo track in
       the firmware. Disable it for CI or release builds to save flash space and
       reduce build times.
+
+endmenu
 
 endmenu

--- a/platforms/tab5/main/idf_component.yml
+++ b/platforms/tab5/main/idf_component.yml
@@ -1,19 +1,15 @@
-## IDF Component Manager Manifest File
+version: "0.1.0"
+
 dependencies:
-  ## Required IDF version
   idf: "~5.4"
-  espressif/esp_hosted:
-    version: 1.4.0
-    rules:
-      - if: "$CONFIG{CONFIG_APP_ENABLE_WIFI_HOSTED} == y"
-  espressif/esp_wifi_remote:
-    version: 0.8.5
-    rules:
-      - if: "$CONFIG{CONFIG_APP_ENABLE_WIFI_HOSTED} == y"
-  chmorgan/esp-audio-player: 1.0.7
-  chmorgan/esp-file-iterator: 1.0.0
-  espressif/led_strip: 3.0.0
-  espressif/esp_lcd_ili9881c: ^1.0.1
+
+  espressif/esp_wifi_remote: "*"
+
+  chmorgan/esp-audio-player: "1.0.7"
+  chmorgan/esp-file-iterator: "1.0.0"
+  espressif/led_strip: "3.0.0"
+  espressif/esp_lcd_ili9881c: "^1.0.1"
+
   settings_core:
     path: ../../../components/settings_core
   settings_ui:


### PR DESCRIPTION
## Summary
- remove the direct esp_hosted manifest entry in favour of esp_wifi_remote and keep local components local
- define the project Wi-Fi toggle in Kconfig with a sensible default
- harden the CI build by guarding against the bogus dependency and forcing a fresh resolve

## Testing
- idf.py reconfigure
- idf.py build

------
https://chatgpt.com/codex/tasks/task_e_68d15bda29048324a89ea130cf01ef15