### PR TITLE
fix: resolve launcher view controller includes

### DIFF
--- a/app/apps/app_launcher/view/view.cpp
+++ b/app/apps/app_launcher/view/view.cpp
@@ -7,7 +7,6 @@
 
 #include <lvgl.h>
 #include <mooncake_log.h>
-
 #include <smooth_lvgl.h>
 #include <string>
 
@@ -22,7 +21,6 @@ using namespace launcher_view;
 using custom::integration::CctvController;
 using custom::integration::MediaController;
 using custom::integration::SettingsController;
-using smooth_ui_toolkit::LvglLockGuard;
 
 static const std::string _tag = "launcher-view";
 

--- a/app/apps/app_launcher/view/view.h
+++ b/app/apps/app_launcher/view/view.h
@@ -6,8 +6,9 @@
 #pragma once
 #include <memory>
 
-
-#include <memory>
+#include "integration/cctv_controller.h"
+#include "integration/media_controller.h"
+#include "integration/settings_controller.h"
 struct ui_root_t;
 
 namespace launcher_view


### PR DESCRIPTION
## Summary
- include the custom integration controllers in the launcher view header so the smart pointers compile
- drop the unused smooth_ui_toolkit alias in the launcher view implementation

## Testing
- idf.py build

------
https://chatgpt.com/codex/tasks/task_e_68d184b3516c8324b5feef78ce7503da