### PR TITLE
Fix launcher view initialization

### DIFF
--- a/app/apps/app_launcher/app_launcher.cpp
+++ b/app/apps/app_launcher/app_launcher.cpp
@@ -4,11 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 #include "app_launcher.h"
-#include "ui_home.h"
-#include <hal/hal.h>
-#include <mooncake.h>
+
 #include <mooncake_log.h>
-#include <smooth_lvgl.h>
 
 using namespace mooncake;
 
@@ -28,12 +25,23 @@ void AppLauncher::onOpen()
 {
     mclog::tagInfo(getAppInfo().name, "on open");
 
-    ui_home_create(nullptr);
+    if (_view == nullptr)
+    {
+        _view = std::make_unique<launcher_view::LauncherView>();
+    }
+
+    if (_view != nullptr)
+    {
+        _view->init();
+    }
 }
 
 void AppLauncher::onRunning()
 {
-    // Static wireframe has no dynamic updates yet.
+    if (_view != nullptr)
+    {
+        _view->update();
+    }
 }
 
 void AppLauncher::onClose()

--- a/app/apps/app_launcher/view/view.cpp
+++ b/app/apps/app_launcher/view/view.cpp
@@ -177,12 +177,14 @@ void LauncherView::update()
 
 LauncherView::~LauncherView()
 {
-    _media_controller.reset();
-    _cctv_controller.reset();
-    _settings_controller.reset();
     if (_ui_root != nullptr)
     {
+        LvglLockGuard lock;
         ui_root_destroy(_ui_root);
         _ui_root = nullptr;
     }
+
+    _media_controller.reset();
+    _cctv_controller.reset();
+    _settings_controller.reset();
 }


### PR DESCRIPTION
## Summary
- construct the launcher view when the app opens and route updates through it
- guard LVGL destruction in LauncherView with LvglLockGuard to avoid invalidate asserts

## Testing
- bash scripts/preflight.sh
- ctest --test-dir build/tests --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d1af5d12a88324a484f7bf993e5a24