### PR TITLE
fix(platform): restore touch input driver

### DIFF
--- a/platforms/tab5/main/hal/hal_esp32.cpp
+++ b/platforms/tab5/main/hal/hal_esp32.cpp
@@ -122,12 +122,23 @@ void HalEsp32::init()
     lv_display_set_rotation(lvDisp, LV_DISPLAY_ROTATION_90);
     bsp_display_backlight_on();
 
-    // // Touchpad lvgl indev
-    // mclog::tagInfo(_tag, "create lvgl touchpad indev");
-    // lvTouchpad = lv_indev_create();
-    // lv_indev_set_type(lvTouchpad, LV_INDEV_TYPE_POINTER);
-    // lv_indev_set_read_cb(lvTouchpad, lvgl_read_cb);
-    // lv_indev_set_display(lvTouchpad, lvDisp);
+    lvTouchpad = bsp_display_get_input_dev();
+    if (lvTouchpad == nullptr)
+    {
+        mclog::tagWarn(_tag, "LVGL touch input not provided by BSP; creating fallback driver");
+
+        lvTouchpad = lv_indev_create();
+        if (lvTouchpad == nullptr)
+        {
+            mclog::tagError(_tag, "Failed to allocate LVGL touch input device");
+        }
+        else
+        {
+            lv_indev_set_type(lvTouchpad, LV_INDEV_TYPE_POINTER);
+            lv_indev_set_read_cb(lvTouchpad, lvgl_read_cb);
+            lv_indev_set_display(lvTouchpad, lvDisp);
+        }
+    }
 
     mclog::tagInfo(_tag, "usb host init");
     bsp_usb_host_start(BSP_USB_HOST_POWER_MODE_USB_DEV, true);


### PR DESCRIPTION
## Summary
- fetch the LVGL touch input handle from the BSP and log a fallback path when it is absent
- create a local LVGL pointer device if the BSP did not register one so touch input stays functional

## Testing
- bash scripts/preflight.sh

------
https://chatgpt.com/codex/tasks/task_e_68d1b83775348324a4f40e0c2b5466ad