### PR TITLE
fix: address Tab5 touch build regressions

### DIFF
--- a/platforms/tab5/main/hal/hal_esp32.cpp
+++ b/platforms/tab5/main/hal/hal_esp32.cpp
@@ -42,12 +42,66 @@ static void lvgl_read_cb(lv_indev_t* indev, lv_indev_data_t* data)
     if (!touchpad_pressed)
     {
         data->state = LV_INDEV_STATE_REL;
+        return;
     }
-    else
+
+    lv_display_t*         disp                 = lv_indev_get_display(indev);
+    lv_display_rotation_t rotation             = LV_DISPLAY_ROTATION_0;
+    lv_coord_t            raw_w                = BSP_LCD_H_RES;
+    lv_coord_t            raw_h                = BSP_LCD_V_RES;
+    static bool           logged_right_edge_ok = false;
+
+    if (disp != nullptr)
     {
-        data->state   = LV_INDEV_STATE_PR;
-        data->point.x = touch_x[0];
-        data->point.y = touch_y[0];
+        rotation = lv_display_get_rotation(disp);
+
+        lv_coord_t phys_w = lv_display_get_physical_horizontal_resolution(disp);
+        lv_coord_t phys_h = lv_display_get_physical_vertical_resolution(disp);
+        if (phys_w > 0)
+        {
+            raw_w = phys_w;
+        }
+        if (phys_h > 0)
+        {
+            raw_h = phys_h;
+        }
+    }
+
+    lv_coord_t transformed_x = touch_x[0];
+    lv_coord_t transformed_y = touch_y[0];
+
+    switch (rotation)
+    {
+        case LV_DISPLAY_ROTATION_90:
+            transformed_x = touch_y[0];
+            transformed_y = raw_w - 1 - touch_x[0];
+            break;
+        case LV_DISPLAY_ROTATION_180:
+            transformed_x = raw_w - 1 - touch_x[0];
+            transformed_y = raw_h - 1 - touch_y[0];
+            break;
+        case LV_DISPLAY_ROTATION_270:
+            transformed_x = raw_h - 1 - touch_y[0];
+            transformed_y = touch_x[0];
+            break;
+        case LV_DISPLAY_ROTATION_0:
+        default:
+            break;
+    }
+
+    data->state   = LV_INDEV_STATE_PR;
+    data->point.x = transformed_x;
+    data->point.y = transformed_y;
+
+    lv_coord_t right_edge_threshold = LV_MAX(raw_w - 5, 0);
+    if (!logged_right_edge_ok && rotation == LV_DISPLAY_ROTATION_90
+        && transformed_x >= right_edge_threshold)
+    {
+        mclog::tagInfo(_tag,
+                       "Touch rotation check: right edge press mapped to ({}, {})",
+                       static_cast<int>(transformed_x),
+                       static_cast<int>(transformed_y));
+        logged_right_edge_ok = true;
     }
 }
 


### PR DESCRIPTION
## Summary
- silence unused-variable diagnostics in the Tab5 BSP by marking the GPIO/gain handles and ST7123 debug helper as intentionally unused
- update the BSP LVGL touch callback to use the panel width for the right-edge regression log and print `lv_coord_t` values with the correct format
- mirror the right-edge threshold fix in the HAL fallback touch handler

## Testing
- `idf.py build` *(fails: `idf.py` is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d230d58010832490cdff4de5656124